### PR TITLE
Es admin og sok tilpasning

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/AdminController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/AdminController.kt
@@ -18,7 +18,7 @@ class AdminController(private val adminService: AdminService) {
     @GetMapping("/internal/elasticadmin/nuke", produces = ["application/json"])
     fun resetElasticIndex(): ElasticAdminResponse {
         //TODO: Make this more fancy.. Need auth, need a service, need to reindex from db.
-        adminService.deleteAllInES()
+        adminService.recreateEsIndex()
         adminService.syncEsWithDb()
         adminService.findAndLogOutOfSyncKlagebehandlinger()
 

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingerQueryParamsMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingerQueryParamsMapper.kt
@@ -21,7 +21,7 @@ class KlagebehandlingerQueryParamsMapper(private val saksbehandlerRepository: Sa
     fun toSearchCriteria(navIdent: String, queryParams: KlagebehandlingerQueryParams) = KlagebehandlingerSearchCriteria(
         typer = queryParams.typer.map { Sakstype.of(it) },
         temaer = queryParams.temaer.map { Tema.of(it) },
-        hjemler = queryParams.hjemler,
+        hjemler = queryParams.hjemler.mapNotNull { toIntOrNull(it) },
         order = if (queryParams.rekkefoelge == KlagebehandlingerQueryParams.Rekkefoelge.SYNKENDE) {
             KlagebehandlingerSearchCriteria.Order.DESC
         } else {
@@ -40,11 +40,17 @@ class KlagebehandlingerQueryParamsMapper(private val saksbehandlerRepository: Sa
         }
     )
 
+    private fun toIntOrNull(it: String) = try {
+        it.toInt()
+    } catch (e: Exception) {
+        null
+    }
+
     fun toFristUtgaattIkkeTildeltSearchCriteria(navIdent: String, queryParams: KlagebehandlingerQueryParams) =
         KlagebehandlingerSearchCriteria(
             typer = queryParams.typer.map { Sakstype.of(it) },
             temaer = queryParams.temaer.map { Tema.of(it) },
-            hjemler = queryParams.hjemler,
+            hjemler = queryParams.hjemler.mapNotNull { toIntOrNull(it) },
             offset = 0,
             limit = 1,
             erTildeltSaksbehandler = false,

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingerQueryParamsMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingerQueryParamsMapper.kt
@@ -40,17 +40,11 @@ class KlagebehandlingerQueryParamsMapper(private val saksbehandlerRepository: Sa
         }
     )
 
-    private fun toIntOrNull(it: String) = try {
-        it.toInt()
-    } catch (e: Exception) {
-        null
-    }
-
     fun toFristUtgaattIkkeTildeltSearchCriteria(navIdent: String, queryParams: KlagebehandlingerQueryParams) =
         KlagebehandlingerSearchCriteria(
             typer = queryParams.typer.map { Sakstype.of(it) },
             temaer = queryParams.temaer.map { Tema.of(it) },
-            hjemler = queryParams.hjemler.mapNotNull { toIntOrNull(it) },
+            hjemler = queryParams.hjemler.mapNotNull { it.toIntOrNull() },
             offset = 0,
             limit = 1,
             erTildeltSaksbehandler = false,

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/KlagebehandlingerSearchCriteria.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/KlagebehandlingerSearchCriteria.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 data class KlagebehandlingerSearchCriteria(
     val typer: List<Sakstype> = emptyList(),
     val temaer: List<Tema> = emptyList(),
-    val hjemler: List<String> = emptyList(),
+    val hjemler: List<Int> = emptyList(),
     val statuskategori: Statuskategori = Statuskategori.AAPEN,
 
     val opprettetFom: LocalDateTime? = null,

--- a/src/main/kotlin/no/nav/klage/oppgave/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/AdminService.kt
@@ -21,6 +21,10 @@ class AdminService(private val indexService: IndexService) {
         Thread.sleep(TWO_SECONDS)
     }
 
+    fun recreateEsIndex() {
+        indexService.recreateIndex()
+    }
+
     @Scheduled(cron = "0 0 3 * * *", zone = "Europe/Paris")
     fun findAndLogOutOfSyncKlagebehandlinger() =
         indexService.findAndLogOutOfSyncKlagebehandlinger()

--- a/src/main/kotlin/no/nav/klage/oppgave/service/IndexService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/IndexService.kt
@@ -84,4 +84,8 @@ class IndexService(
         }
     }
 
+    fun recreateIndex() {
+        elasticsearchRepository.recreateIndex()
+    }
+
 }

--- a/src/main/resources/elasticsearch/mapping.json
+++ b/src/main/resources/elasticsearch/mapping.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "journalpostId": {
-      "type": "long"
+      "type": "keyword"
     },
     "saksreferanse": {
       "type": "keyword"
@@ -48,12 +48,7 @@
       "format": "date"
     },
     "hjemler": {
-      "type": "keyword",
-      "fields": {
-        "text": {
-          "type": "text"
-        }
-      }
+      "type": "keyword"
     },
     "foedselsnummer": {
       "type": "keyword"

--- a/src/test/kotlin/no/nav/klage/oppgave/service/CreateIndexFromEsOppgaveTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/CreateIndexFromEsOppgaveTest.kt
@@ -9,10 +9,7 @@ import org.apache.http.util.EntityUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.elasticsearch.client.Request
 import org.elasticsearch.client.RestHighLevelClient
-import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
@@ -32,7 +29,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 @SpringBootTest(classes = [RetryConfig::class])
 @ImportAutoConfiguration(ElasticsearchRestClientAutoConfiguration::class, ElasticsearchDataAutoConfiguration::class)
-//@Disabled("kan brukes for å generere settings og mapping, for så å lagre som fil. Må da endre i ElasticsearchService")
+@Disabled("kan brukes for å generere settings og mapping, for så å lagre som fil. Må da endre i ElasticsearchService")
 class CreateIndexFromEsOppgaveTest {
 
     companion object {

--- a/src/test/kotlin/no/nav/klage/oppgave/service/CreateIndexFromEsOppgaveTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/CreateIndexFromEsOppgaveTest.kt
@@ -9,7 +9,10 @@ import org.apache.http.util.EntityUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.elasticsearch.client.Request
 import org.elasticsearch.client.RestHighLevelClient
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
@@ -29,7 +32,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 @SpringBootTest(classes = [RetryConfig::class])
 @ImportAutoConfiguration(ElasticsearchRestClientAutoConfiguration::class, ElasticsearchDataAutoConfiguration::class)
-@Disabled("kan brukes for å generere settings og mapping, for så å lagre som fil. Må da endre i ElasticsearchService")
+//@Disabled("kan brukes for å generere settings og mapping, for så å lagre som fil. Må da endre i ElasticsearchService")
 class CreateIndexFromEsOppgaveTest {
 
     companion object {


### PR DESCRIPTION
Lagt til (midlertidig) kode for å parse hjemler fra gui om til int. Gjort så vi sletter og gjenskaper indexen når vi nuker den, ikke bare sletter alle dokumentene i den. Oppdatert mappingen med riktig definisjon for hjemler