### PR TITLE
Lagt til støtte for shedlock så scheduled tasks bare skal kjøre på en pod

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ val testContainersVersion = "1.15.1"
 val tikaVersion = "1.24.1"
 val nimbusVersion = "8.20.1"
 val threeTenExtraVersion = "1.6.0"
+val shedlockVersion = "4.23.0"
 
 val githubUser: String by project
 val githubPassword: String by project
@@ -61,6 +62,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
+
+    implementation("net.javacrumbs.shedlock:shedlock-spring:$shedlockVersion")
+    implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:$shedlockVersion")
 
     implementation("org.springframework.kafka:spring-kafka")
     implementation("io.confluent:kafka-avro-serializer:$kafkaAvroVersion") {

--- a/src/main/kotlin/no/nav/klage/oppgave/config/SchedulingConfiguration.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/config/SchedulingConfiguration.kt
@@ -1,11 +1,30 @@
 package no.nav.klage.oppgave.config
 
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
+import javax.sql.DataSource
+
 
 @Configuration
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
 @EnableAsync
 class SchedulingConfiguration {
+
+    @Bean
+    fun lockProvider(dataSource: DataSource): LockProvider {
+        return JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(JdbcTemplate(dataSource))
+                .withTableName("klage.shedlock")
+                .usingDbTime()
+                .build()
+        )
+    }
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/service/AdminService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/AdminService.kt
@@ -1,5 +1,6 @@
 package no.nav.klage.oppgave.service
 
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
@@ -26,6 +27,7 @@ class AdminService(private val indexService: IndexService) {
     }
 
     @Scheduled(cron = "0 0 3 * * *", zone = "Europe/Paris")
+    @SchedulerLock(name = "findAndLogOutOfSyncKlagebehandlinger")
     fun findAndLogOutOfSyncKlagebehandlinger() =
         indexService.findAndLogOutOfSyncKlagebehandlinger()
 

--- a/src/main/resources/db/migration/V2__Create_shedlock.sql
+++ b/src/main/resources/db/migration/V2__Create_shedlock.sql
@@ -1,0 +1,8 @@
+CREATE TABLE klage.shedlock
+(
+    name       VARCHAR(64)  NOT NULL,
+    lock_until TIMESTAMP    NOT NULL,
+    locked_at  TIMESTAMP    NOT NULL,
+    locked_by  VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);


### PR DESCRIPTION
Dette kunne vært håndtert på en rekke andre måter også, men jeg tenkte at siden vi allerede bruker Postgres, så gjør det ikke noe å ha en dependency til det også i dette tilfelle, og shedlock har jeg erfaring med fra før, så det var kjapt å få på plass.