### PR TITLE
Utvid og tydeliggjør er/harMedunderskriver

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
@@ -164,9 +164,8 @@ class KlagebehandlingMapper(
                 mottatt = esKlagebehandling.mottattKlageinstans?.toLocalDate(),
                 versjon = esKlagebehandling.versjon!!.toInt(),
                 klagebehandlingVersjon = esKlagebehandling.versjon,
-                erMedunderskriver = if (esKlagebehandling.medunderskriverident != null) {
-                    esKlagebehandling.medunderskriverident == saksbehandler
-                } else null,
+                erMedunderskriver = esKlagebehandling.medunderskriverident != null && esKlagebehandling.medunderskriverident == saksbehandler,
+                harMedunderskriver = esKlagebehandling.medunderskriverident != null,
                 utfall = if (viseFullfoerte) {
                     esKlagebehandling.vedtakUtfall
                 } else {

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingListView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingListView.kt
@@ -17,7 +17,8 @@ data class KlagebehandlingListView(
     val mottatt: LocalDate?,
     val versjon: Int,
     val klagebehandlingVersjon: Long,
-    val erMedunderskriver: Boolean?,
+    val erMedunderskriver: Boolean = false,
+    val harMedunderskriver: Boolean = false,
     val utfall: String?,
     val avsluttet: LocalDate?,
     val avsluttetAvSaksbehandler: LocalDate?


### PR DESCRIPTION
I frontend er det antatt at `erMedunderskriver` er `string` eller `null`.
I backend er `erMedunderskriver` `boolean` eller `null`.

Jeg forslår at vi renskriver dette til at `erMedunderskriver` er `boolean` og at vi utvider med en ny egenskap som indikerer om det er en medunderskriver (`harMedunderskriver`), som også er `boolean`.