### PR TITLE
Fiks vedtak fil null for behandlingsdetaljer

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingVedtakController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingVedtakController.kt
@@ -59,8 +59,7 @@ class KlagebehandlingVedtakController(
                 vedtakId.toUUIDOrException()
             ),
             vedtakService.getVedleggView(
-                klagebehandling,
-                vedtakId.toUUIDOrException(),
+                klagebehandling.getVedtak(vedtakId.toUUIDOrException()),
                 innloggetSaksbehandlerRepository.getInnloggetIdent()
             )
         )
@@ -181,8 +180,7 @@ class KlagebehandlingVedtakController(
             innloggetSaksbehandlerRepository.getInnloggetIdent()
         )
         val vedleggView = vedtakService.getVedleggView(
-            klagebehandling,
-            vedtakId.toUUIDOrException(),
+            klagebehandling.getVedtak(vedtakId.toUUIDOrException()),
             innloggetSaksbehandlerRepository.getInnloggetIdent()
         )
         val responseHeaders = HttpHeaders()

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
@@ -16,6 +16,8 @@ import no.nav.klage.oppgave.domain.klage.Klagebehandling
 import no.nav.klage.oppgave.domain.klage.PartId
 import no.nav.klage.oppgave.domain.klage.Vedtak
 import no.nav.klage.oppgave.domain.kodeverk.PartIdType
+import no.nav.klage.oppgave.repositories.InnloggetSaksbehandlerRepository
+import no.nav.klage.oppgave.service.VedtakService
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.klage.oppgave.util.getSecureLogger
 import org.springframework.stereotype.Service
@@ -26,7 +28,9 @@ class KlagebehandlingMapper(
     private val pdlFacade: PdlFacade,
     private val egenAnsattService: EgenAnsattService,
     private val norg2Client: Norg2Client,
-    private val eregClient: EregClient
+    private val eregClient: EregClient,
+    private val vedtakService: VedtakService,
+    private val innloggetSaksbehandlerRepository: InnloggetSaksbehandlerRepository,
 ) {
 
     companion object {
@@ -239,7 +243,10 @@ class KlagebehandlingMapper(
             sendTilbakemelding = klagebehandling.kvalitetsvurdering?.sendTilbakemelding,
             tilbakemelding = klagebehandling.kvalitetsvurdering?.tilbakemelding,
             klagebehandlingVersjon = klagebehandling.versjon,
-            vedtak = klagebehandling.vedtak.map { mapVedtakToVedtakView(it) },
+            vedtak = klagebehandling.vedtak.map { mapVedtakToVedtakView(it, vedtakService.getVedleggView(
+                it,
+                innloggetSaksbehandlerRepository.getInnloggetIdent()
+            )) },
             kommentarFraFoersteinstans = klagebehandling.kommentarFraFoersteinstans
         )
     }

--- a/src/main/kotlin/no/nav/klage/oppgave/service/VedtakService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/VedtakService.kt
@@ -220,8 +220,7 @@ class VedtakService(
         )
 
         return getVedleggView(
-            klagebehandling,
-            vedtakId,
+            klagebehandling.getVedtak(vedtakId),
             innloggetIdent
         )
     }
@@ -251,12 +250,10 @@ class VedtakService(
     }
 
     fun getVedleggView(
-        klagebehandling: Klagebehandling,
-        vedtakId: UUID,
+        vedtak: Vedtak,
         utfoerendeSaksbehandlerIdent: String
     ): VedleggView? {
-        val vedtak = klagebehandling.getVedtak(vedtakId)
-        if (vedtak.journalpostId == null) throw JournalpostNotFoundException("Vedtak med id $vedtakId er ikke journalført")
+        if (vedtak.journalpostId == null) throw JournalpostNotFoundException("Vedtak med id ${vedtak.id} er ikke journalført")
         val mainDokument = dokumentService.getMainDokument(vedtak.journalpostId!!)
         val mainDokumentName = dokumentService.getMainDokumentTitle(vedtak.journalpostId!!)
         return klagebehandlingMapper.mapArkivertDokumentToVedleggView(


### PR DESCRIPTION
`GET /klagebehandlinger/{id}/detaljer`
Ved henting av en klagebehandling var `vedtak.file` alltid `null`.