### PR TITLE
Et forsøk på å bli kvitt feil i loggene ved shutdown

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/config/FunksjonelleGaugesConfiguration.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/config/FunksjonelleGaugesConfiguration.kt
@@ -4,12 +4,25 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.binder.MeterBinder
 import no.nav.klage.oppgave.service.ElasticsearchService
+import no.nav.klage.oppgave.util.getLogger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import javax.annotation.PreDestroy
 
 
 @Configuration
 class FunksjonelleGaugesConfiguration {
+
+    companion object {
+        @Suppress("JAVA_CLASS_ON_COMPANION")
+        private val logger = getLogger(javaClass.enclosingClass)
+    }
+
+    @PreDestroy
+    fun onDestroy(registry: MeterRegistry) {
+        logger.info("We have received a SIGTERM (?)")
+        if (!registry.isClosed) registry.close()
+    }
 
     @Bean
     fun registerFunctionalStats(elasticsearchService: ElasticsearchService): MeterBinder {


### PR DESCRIPTION
Jeg håper at denne fiksen kan gjøre at noen av feilene vi ser i loggene blir borte, spesifikt disse:

Failed to apply the value function for the gauge 'funksjonell.sendttilmedunderskriver'.
failed to send metrics to influx

Men jeg må innrømme at jeg synes det er rart at ikke Spring/Micrometer gjør dette allerede..