### PR TITLE
Lagt til støtte for filtrering på tema i saf-kallet hentDokumentoversiktBrukerQuery

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingDokumentController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingDokumentController.kt
@@ -45,10 +45,10 @@ class KlagebehandlingDokumentController(
     ): DokumenterResponse {
         val klagebehandlingId = parseAndValidate(behandlingsid)
         return klagebehandlingService.fetchDokumentlisteForKlagebehandling(
-            klagebehandlingId,
-            null,
-            pageSize,
-            previousPageRef
+            klagebehandlingId = klagebehandlingId,
+            temaer = emptyList(),
+            pageSize = pageSize,
+            previousPageRef = previousPageRef
         )
     }
 

--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingDokumentController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingDokumentController.kt
@@ -44,7 +44,12 @@ class KlagebehandlingDokumentController(
         @RequestParam(required = false, name = "forrigeSide") previousPageRef: String? = null
     ): DokumenterResponse {
         val klagebehandlingId = parseAndValidate(behandlingsid)
-        return klagebehandlingService.fetchDokumentlisteForKlagebehandling(klagebehandlingId, pageSize, previousPageRef)
+        return klagebehandlingService.fetchDokumentlisteForKlagebehandling(
+            klagebehandlingId,
+            null,
+            pageSize,
+            previousPageRef
+        )
     }
 
     //TODO: Blir denne brukt?

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/saf/graphql/HentDokumentoversiktBrukerRequest.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/saf/graphql/HentDokumentoversiktBrukerRequest.kt
@@ -5,12 +5,19 @@ data class HentDokumentoversiktBrukerGraphqlQuery(
     val variables: DokumentoversiktBrukerVariables
 )
 
-data class DokumentoversiktBrukerVariables(val brukerId: BrukerId, val foerste: Int, val etter: String?)
+data class DokumentoversiktBrukerVariables(
+    val brukerId: BrukerId,
+    val tema: List<Tema>?,
+    val foerste: Int,
+    val etter: String?,
+)
+
 data class BrukerId(val id: String, val type: BrukerIdType = BrukerIdType.FNR)
 enum class BrukerIdType { FNR }
 
 fun hentDokumentoversiktBrukerQuery(
     fnr: String,
+    tema: List<Tema>?, //Hvis en tom liste er angitt som argument hentes journalposter på alle tema.
     pageSize: Int,
     previousPageRef: String?
 ): HentDokumentoversiktBrukerGraphqlQuery {
@@ -19,6 +26,6 @@ fun hentDokumentoversiktBrukerQuery(
             .readText().replace("[\n\r]", "")
     return HentDokumentoversiktBrukerGraphqlQuery(
         query,
-        DokumentoversiktBrukerVariables(BrukerId(fnr), pageSize, previousPageRef)
+        DokumentoversiktBrukerVariables(BrukerId(fnr), tema, pageSize, previousPageRef)
     )
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/saf/graphql/HentDokumentoversiktBrukerRequest.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/saf/graphql/HentDokumentoversiktBrukerRequest.kt
@@ -26,6 +26,11 @@ fun hentDokumentoversiktBrukerQuery(
             .readText().replace("[\n\r]", "")
     return HentDokumentoversiktBrukerGraphqlQuery(
         query,
-        DokumentoversiktBrukerVariables(BrukerId(fnr), tema, pageSize, previousPageRef)
+        DokumentoversiktBrukerVariables(
+            BrukerId(fnr),
+            if (tema.isNullOrEmpty()) null else tema,
+            pageSize,
+            previousPageRef
+        )
     )
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/saf/graphql/SafGraphQlClient.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/saf/graphql/SafGraphQlClient.kt
@@ -26,6 +26,7 @@ class SafGraphQlClient(
     @Retryable
     fun getDokumentoversiktBruker(
         fnr: String,
+        tema: List<Tema>?,
         pageSize: Int,
         previousPageRef: String? = null
     ): DokumentoversiktBruker {
@@ -38,7 +39,7 @@ class SafGraphQlClient(
                 )
                 .header("Nav-Callid", tracer.currentSpan().context().traceIdString())
 
-                .bodyValue(hentDokumentoversiktBrukerQuery(fnr, pageSize, previousPageRef))
+                .bodyValue(hentDokumentoversiktBrukerQuery(fnr, tema, pageSize, previousPageRef))
                 .retrieve()
                 .bodyToMono<DokumentoversiktBrukerResponse>()
                 .block()

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/saf/graphql/SafGraphQlClient.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/saf/graphql/SafGraphQlClient.kt
@@ -26,7 +26,7 @@ class SafGraphQlClient(
     @Retryable
     fun getDokumentoversiktBruker(
         fnr: String,
-        tema: List<Tema>?,
+        tema: List<Tema>,
         pageSize: Int,
         previousPageRef: String? = null
     ): DokumentoversiktBruker {

--- a/src/main/kotlin/no/nav/klage/oppgave/service/DokumentService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/DokumentService.kt
@@ -28,7 +28,7 @@ class DokumentService(
 
     fun fetchDokumentlisteForKlagebehandling(
         klagebehandling: Klagebehandling,
-        temaer: List<Tema>?,
+        temaer: List<Tema>,
         pageSize: Int,
         previousPageRef: String?
     ): DokumenterResponse {
@@ -57,9 +57,9 @@ class DokumentService(
         }
     }
 
-    private fun mapTema(temaer: List<Tema>?): List<no.nav.klage.oppgave.clients.saf.graphql.Tema>? {
-        return temaer?.let { temaer -> temaer.map { tema -> no.nav.klage.oppgave.clients.saf.graphql.Tema.valueOf(tema.name) } }
-    }
+    private fun mapTema(temaer: List<Tema>): List<no.nav.klage.oppgave.clients.saf.graphql.Tema> =
+        temaer.map { tema -> no.nav.klage.oppgave.clients.saf.graphql.Tema.valueOf(tema.name) }
+    
 
     fun fetchJournalposterConnectedToKlagebehandling(klagebehandling: Klagebehandling): DokumenterResponse {
         val dokumentReferanser = klagebehandling.saksdokumenter

--- a/src/main/kotlin/no/nav/klage/oppgave/service/DokumentService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/DokumentService.kt
@@ -8,6 +8,7 @@ import no.nav.klage.oppgave.clients.saf.rest.SafRestClient
 import no.nav.klage.oppgave.domain.ArkivertDokumentWithTitle
 import no.nav.klage.oppgave.domain.klage.Klagebehandling
 import no.nav.klage.oppgave.domain.klage.Saksdokument
+import no.nav.klage.oppgave.domain.kodeverk.Tema
 import no.nav.klage.oppgave.exceptions.JournalpostNotFoundException
 import no.nav.klage.oppgave.util.getLogger
 import org.springframework.stereotype.Service
@@ -27,6 +28,7 @@ class DokumentService(
 
     fun fetchDokumentlisteForKlagebehandling(
         klagebehandling: Klagebehandling,
+        temaer: List<Tema>?,
         pageSize: Int,
         previousPageRef: String?
     ): DokumenterResponse {
@@ -34,6 +36,7 @@ class DokumentService(
             val dokumentoversiktBruker: DokumentoversiktBruker =
                 safGraphQlClient.getDokumentoversiktBruker(
                     klagebehandling.sakenGjelder.partId.value,
+                    mapTema(temaer),
                     pageSize,
                     previousPageRef
                 )
@@ -52,6 +55,10 @@ class DokumentService(
         } else {
             return DokumenterResponse(dokumenter = emptyList(), pageReference = null, antall = 0, totaltAntall = 0)
         }
+    }
+
+    private fun mapTema(temaer: List<Tema>?): List<no.nav.klage.oppgave.clients.saf.graphql.Tema>? {
+        return temaer?.let { temaer -> temaer.map { tema -> no.nav.klage.oppgave.clients.saf.graphql.Tema.valueOf(tema.name) } }
     }
 
     fun fetchJournalposterConnectedToKlagebehandling(klagebehandling: Klagebehandling): DokumenterResponse {

--- a/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
@@ -500,7 +500,7 @@ class KlagebehandlingService(
 
     fun fetchDokumentlisteForKlagebehandling(
         klagebehandlingId: UUID,
-        temaer: List<Tema>?,
+        temaer: List<Tema>,
         pageSize: Int,
         previousPageRef: String?
     ): DokumenterResponse {

--- a/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
@@ -500,11 +500,12 @@ class KlagebehandlingService(
 
     fun fetchDokumentlisteForKlagebehandling(
         klagebehandlingId: UUID,
+        temaer: List<Tema>?,
         pageSize: Int,
         previousPageRef: String?
     ): DokumenterResponse {
         val klagebehandling = getKlagebehandling(klagebehandlingId)
-        return dokumentService.fetchDokumentlisteForKlagebehandling(klagebehandling, pageSize, previousPageRef)
+        return dokumentService.fetchDokumentlisteForKlagebehandling(klagebehandling, temaer, pageSize, previousPageRef)
     }
 
     fun fetchJournalpostIderConnectedToKlagebehandling(klagebehandlingId: UUID): List<String> =

--- a/src/main/resources/saf/hentDokumentoversiktBruker.graphql
+++ b/src/main/resources/saf/hentDokumentoversiktBruker.graphql
@@ -1,7 +1,8 @@
-query($brukerId: BrukerIdInput!, $foerste: Int, $etter: String) {
+query($brukerId: BrukerIdInput!, $tema: [Tema!], $foerste: Int, $etter: String) {
     dokumentoversiktBruker(
         brukerId: $brukerId,
-        journalstatuser: [FERDIGSTILT,JOURNALFOERT,EKSPEDERT, MOTTATT]
+        tema: $tema,
+        journalstatuser: [FERDIGSTILT,JOURNALFOERT,EKSPEDERT, MOTTATT],
         foerste: $foerste,
         etter: $etter) {
         journalposter {

--- a/src/test/kotlin/no/nav/klage/oppgave/clients/SafDokumentoversiktBrukerTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/clients/SafDokumentoversiktBrukerTest.kt
@@ -55,7 +55,7 @@ internal class SafDokumentoversiktBrukerTest {
             tracerMock
         )
 
-        return safClient.getDokumentoversiktBruker("fnr", 1, null)
+        return safClient.getDokumentoversiktBruker("fnr", null, 1, null)
     }
 
     @Language("json")

--- a/src/test/kotlin/no/nav/klage/oppgave/clients/SafDokumentoversiktBrukerTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/clients/SafDokumentoversiktBrukerTest.kt
@@ -55,7 +55,7 @@ internal class SafDokumentoversiktBrukerTest {
             tracerMock
         )
 
-        return safClient.getDokumentoversiktBruker("fnr", null, 1, null)
+        return safClient.getDokumentoversiktBruker("fnr", emptyList(), 1, null)
     }
 
     @Language("json")


### PR DESCRIPTION
Har ikke lagt det til i apiet i KlagebehandlingDokumentController ennå, tenkte det kunne være en egen endring

Denne endringen trengs for å få til https://trello.com/c/WjuM4mgN/270-kunne-filtrere-p%C3%A5-tema-i-dokumentlista-i-kabal-saksbehandling.

Jeg har prøvd å titte på hvordan det er gjort i Lovme da jeg gjorde denne endringen. (Ref https://github.com/navikt/medlemskap-oppslag/blob/master/saf-client/src/main/resources/saf/dokumenter.graphql)