### PR TITLE
Relaterte klager

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingDetaljerController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingDetaljerController.kt
@@ -118,12 +118,12 @@ class KlagebehandlingDetaljerController(
         return KlagebehandlingerListRespons(
             antallTreffTotalt = esResponse.totalHits.toInt(),
             klagebehandlinger = klagebehandlingListMapper.mapEsKlagebehandlingerToListView(
-                esResponse.searchHits.map { it.content },
-                true,
-                true,
-                searchCriteria.saksbehandler,
-                lovligeTemaer,
-                sivilstand
+                esKlagebehandlinger = esResponse.searchHits.map { it.content },
+                viseUtvidet = true,
+                viseFullfoerte = true,
+                saksbehandler = searchCriteria.saksbehandler,
+                tilgangTilTemaer = lovligeTemaer,
+                sivilstand = sivilstand
             )
         )
 

--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingDetaljerController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/KlagebehandlingDetaljerController.kt
@@ -98,10 +98,10 @@ class KlagebehandlingDetaljerController(
         }
 
         val sivilstand: Sivilstand? = pdlFacade.getPersonInfo(klagebehandling.sakenGjelder.partId.value).sivilstand
-        
+
         val searchCriteria = KlagebehandlingerSearchCriteria(
             statuskategori = KlagebehandlingerSearchCriteria.Statuskategori.ALLE,
-            ferdigstiltFom = LocalDate.now().minusDays(30),
+            ferdigstiltFom = LocalDate.now().minusMonths(12),
             foedselsnr = listOf(klagebehandling.sakenGjelder.partId.value),
             extraPersonAndTema = sivilstand?.let {
                 KlagebehandlingerSearchCriteria.ExtraPersonAndTema(

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingListMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingListMapper.kt
@@ -3,6 +3,7 @@ package no.nav.klage.oppgave.api.mapper
 
 import no.nav.klage.oppgave.api.view.KlagebehandlingListView
 import no.nav.klage.oppgave.api.view.PersonSoekPersonView
+import no.nav.klage.oppgave.clients.pdl.Sivilstand
 import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.oppgave.domain.kodeverk.Tema
 import no.nav.klage.oppgave.util.getLogger
@@ -48,7 +49,8 @@ class KlagebehandlingListMapper() {
         viseUtvidet: Boolean,
         viseFullfoerte: Boolean,
         saksbehandler: String?,
-        tilgangTilTemaer: List<Tema>
+        tilgangTilTemaer: List<Tema>,
+        sivilstand: Sivilstand? = null
     ): List<KlagebehandlingListView> {
         return esKlagebehandlinger.map { esKlagebehandling ->
             KlagebehandlingListView(
@@ -56,7 +58,8 @@ class KlagebehandlingListMapper() {
                 person = if (viseUtvidet) {
                     KlagebehandlingListView.Person(
                         esKlagebehandling.sakenGjelderFnr,
-                        esKlagebehandling.sakenGjelderNavn
+                        esKlagebehandling.sakenGjelderNavn,
+                        if (esKlagebehandling.sakenGjelderFnr == sivilstand?.foedselsnr) sivilstand?.type?.id else null
                     )
                 } else {
                     null

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingListView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingListView.kt
@@ -25,7 +25,7 @@ data class KlagebehandlingListView(
     val erTildelt: Boolean,
     val tildeltSaksbehandlerident: String?,
     val tildeltSaksbehandlerNavn: String?,
-    val saksbehandlerHarTilgang: Boolean,
+    val saksbehandlerHarTilgang: Boolean
 ) {
     data class Person(
         val fnr: String?,

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingListView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingListView.kt
@@ -25,11 +25,12 @@ data class KlagebehandlingListView(
     val erTildelt: Boolean,
     val tildeltSaksbehandlerident: String?,
     val tildeltSaksbehandlerNavn: String?,
-    val saksbehandlerHarTilgang: Boolean
+    val saksbehandlerHarTilgang: Boolean,
 ) {
     data class Person(
         val fnr: String?,
-        val navn: String?
+        val navn: String?,
+        val sivilstand: String? = null
     )
 }
 

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KodeverkResponse.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KodeverkResponse.kt
@@ -15,7 +15,8 @@ data class KodeverkResponse(
     val partIdType: List<Kode> = PartIdType.values().asList().toDto(),
     val rolle: List<Kode> = Rolle.values().asList().toDto(),
     val fagsystem: List<Kode> = Fagsystem.values().asList().toDto(),
-    val utsendingStatus: List<Kode> = UtsendingStatus.values().asList().toDto()
+    val utsendingStatus: List<Kode> = UtsendingStatus.values().asList().toDto(),
+    val sivilstandType: List<Kode> = SivilstandType.values().asList().toDto()
 
 )
 

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/pdl/Person.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/pdl/Person.kt
@@ -1,5 +1,7 @@
 package no.nav.klage.oppgave.clients.pdl
 
+import no.nav.klage.oppgave.domain.kodeverk.SivilstandType
+
 data class Person(
     val foedselsnr: String,
     val fornavn: String?,
@@ -28,9 +30,4 @@ data class Sivilstand(val type: SivilstandType, val foedselsnr: String)
 
 enum class Beskyttelsesbehov {
     STRENGT_FORTROLIG_UTLAND, STRENGT_FORTROLIG, FORTROLIG
-}
-
-enum class SivilstandType {
-    GIFT,
-    REGISTRERT_PARTNER
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/pdl/graphql/HentPersonMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/pdl/graphql/HentPersonMapper.kt
@@ -3,7 +3,7 @@ package no.nav.klage.oppgave.clients.pdl.graphql
 import no.nav.klage.oppgave.clients.pdl.Beskyttelsesbehov
 import no.nav.klage.oppgave.clients.pdl.Person
 import no.nav.klage.oppgave.clients.pdl.Sivilstand
-import no.nav.klage.oppgave.clients.pdl.SivilstandType
+import no.nav.klage.oppgave.domain.kodeverk.SivilstandType
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.klage.oppgave.util.getSecureLogger
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/KlagebehandlingerSearchCriteria.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/KlagebehandlingerSearchCriteria.kt
@@ -19,6 +19,7 @@ data class KlagebehandlingerSearchCriteria(
     val fristFom: LocalDate? = null,
     val fristTom: LocalDate? = null,
     val foedselsnr: List<String> = emptyList(),
+    val extraPersonAndTema: ExtraPersonAndTema? = null,
 
     val order: Order? = null,
     val offset: Int,
@@ -29,6 +30,8 @@ data class KlagebehandlingerSearchCriteria(
     val projection: Projection? = null,
     val sortField: SortField? = null
 ) {
+
+    data class ExtraPersonAndTema(val foedselsnr: String, val temaer: List<Tema>)
 
     enum class SortField {
         FRIST, MOTTATT

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/kodeverk/SivilstandType.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/kodeverk/SivilstandType.kt
@@ -1,0 +1,41 @@
+package no.nav.klage.oppgave.domain.kodeverk
+
+import io.swagger.annotations.ApiModel
+import javax.persistence.AttributeConverter
+import javax.persistence.Converter
+
+@ApiModel
+enum class SivilstandType(override val id: String, override val navn: String, override val beskrivelse: String) : Kode {
+
+    GIFT("1", "Gift", "Gift"),
+    REGISTRERT_PARTNER("2", "Registrert partner", "Registrert partner")
+    ;
+
+    override fun toString(): String {
+        return "SivilstandType(id=$id, " +
+                "navn=$navn)"
+    }
+
+    companion object {
+        fun of(id: String): SivilstandType {
+            return values().firstOrNull { it.id == id }
+                ?: throw IllegalArgumentException("No SivilstandType with ${id} exists")
+        }
+
+        fun fromNavn(navn: String): SivilstandType {
+            return values().firstOrNull { it.navn == navn }
+                ?: throw IllegalArgumentException("No SivilstandType with ${navn} exists")
+        }
+    }
+}
+
+
+@Converter
+class SivilstandTypeConverter : AttributeConverter<SivilstandType, String?> {
+
+    override fun convertToDatabaseColumn(entity: SivilstandType?): String? =
+        entity?.let { it.id }
+
+    override fun convertToEntityAttribute(id: String?): SivilstandType? =
+        id?.let { SivilstandType.of(it) }
+}

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/kodeverk/Tema.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/kodeverk/Tema.kt
@@ -85,6 +85,18 @@ enum class Tema(override val id: String, override val navn: String, override val
     }
 }
 
+object TemaTilgjengeligeForEktefelle {
+    private val ektefelleTemaerIProdGcp = EnumSet.of(Tema.OMS)
+    private val ektefelleTemaerIDevGcp = EnumSet.of(Tema.OMS)
+
+    fun temaerTilgjengeligForEktefelle(environment: Environment): EnumSet<Tema> =
+        if (environment.activeProfiles.contains("prod-gcp")) {
+            ektefelleTemaerIProdGcp
+        } else {
+            ektefelleTemaerIDevGcp
+        }
+}
+
 object LovligeTemaer {
     private val lovligeTemaerIProdGcp = EnumSet.of(Tema.OMS)
     private val lovligeTemaerIDevGcp = EnumSet.of(Tema.OMS, Tema.SYK)

--- a/src/main/kotlin/no/nav/klage/oppgave/service/ElasticsearchService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/ElasticsearchService.kt
@@ -215,11 +215,11 @@ open class ElasticsearchService(
                 innerTemaEktefelleQuery.should(QueryBuilders.termQuery("tema", tema.id))
             }
         }
-        
+
         when (statuskategori) {
             AAPEN -> baseQuery.mustNot(QueryBuilders.existsQuery("avsluttetAvSaksbehandler"))
             AVSLUTTET -> baseQuery.must(QueryBuilders.existsQuery("avsluttetAvSaksbehandler"))
-            ALLE -> noop()
+            ALLE -> Unit
         }
 
         enhetId?.let {

--- a/src/main/kotlin/no/nav/klage/oppgave/service/ElasticsearchService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/ElasticsearchService.kt
@@ -1,8 +1,7 @@
 package no.nav.klage.oppgave.service
 
 import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
-import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria.Statuskategori.AAPEN
-import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria.Statuskategori.AVSLUTTET
+import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria.Statuskategori.*
 import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling.Status.*
 import no.nav.klage.oppgave.domain.elasticsearch.KlageStatistikk
@@ -195,6 +194,7 @@ open class ElasticsearchService(
         when (statuskategori) {
             AAPEN -> baseQuery.mustNot(QueryBuilders.existsQuery("avsluttetAvSaksbehandler"))
             AVSLUTTET -> baseQuery.must(QueryBuilders.existsQuery("avsluttetAvSaksbehandler"))
+            ALLE -> noop()
         }
 
         enhetId?.let {
@@ -272,6 +272,10 @@ open class ElasticsearchService(
 
         logger.debug("Making search request with query {}", baseQuery.toString())
         return baseQuery
+    }
+
+    private fun noop() {
+        //DO NOTHING
     }
 
     private fun addSecurityFilters(baseQuery: BoolQueryBuilder) {

--- a/src/test/kotlin/no/nav/klage/oppgave/service/EktefelleElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/EktefelleElasticsearchServiceTest.kt
@@ -77,7 +77,7 @@ class EktefelleElasticsearchServiceTest {
 
     @Test
     @Order(3)
-    fun `lagrer to oppgaver for senere tester`() {
+    fun `lagrer fire oppgaver for senere tester`() {
 
         val klagebehandling1 = EsKlagebehandling(
             id = "1001L",
@@ -189,7 +189,7 @@ class EktefelleElasticsearchServiceTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     fun `Klagebehandling can be searched for by fnr and tema`() {
         val klagebehandlinger: List<EsKlagebehandling> =
             service.findByCriteria(
@@ -205,7 +205,7 @@ class EktefelleElasticsearchServiceTest {
     }
 
     @Test
-    @Order(4)
+    @Order(6)
     fun `Klagebehandling can be searched for by ektefelle`() {
         val klagebehandlinger: List<EsKlagebehandling> =
             service.findByCriteria(
@@ -225,7 +225,7 @@ class EktefelleElasticsearchServiceTest {
     }
 
     @Test
-    @Order(4)
+    @Order(7)
     fun `Klagebehandling can be searched for by fnr and ektefelle`() {
         val klagebehandlinger: List<EsKlagebehandling> =
             service.findByCriteria(

--- a/src/test/kotlin/no/nav/klage/oppgave/service/EktefelleElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/EktefelleElasticsearchServiceTest.kt
@@ -1,0 +1,247 @@
+package no.nav.klage.oppgave.service
+
+import com.ninjasquad.springmockk.MockkBean
+import no.nav.klage.oppgave.config.ElasticsearchServiceConfiguration
+import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
+import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
+import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling.Status.IKKE_TILDELT
+import no.nav.klage.oppgave.domain.kodeverk.Tema
+import no.nav.klage.oppgave.domain.kodeverk.Type
+import no.nav.klage.oppgave.repositories.EsKlagebehandlingRepository
+import no.nav.klage.oppgave.repositories.InnloggetSaksbehandlerRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.elasticsearch.index.query.QueryBuilders
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate
+import org.springframework.data.elasticsearch.core.SearchHits
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder
+import org.springframework.data.elasticsearch.core.query.Query
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+
+@ActiveProfiles("local")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@Testcontainers
+@SpringBootTest(classes = [ElasticsearchServiceConfiguration::class])
+@ImportAutoConfiguration(
+    ElasticsearchRestClientAutoConfiguration::class,
+    ElasticsearchDataAutoConfiguration::class
+)
+class EktefelleElasticsearchServiceTest {
+
+    companion object {
+        @Container
+        @JvmField
+        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+    }
+
+    @MockkBean(relaxed = true)
+    lateinit var innloggetSaksbehandlerRepository: InnloggetSaksbehandlerRepository
+
+    @Autowired
+    lateinit var service: ElasticsearchService
+
+    @Autowired
+    lateinit var esTemplate: ElasticsearchRestTemplate
+
+    @Autowired
+    lateinit var repo: EsKlagebehandlingRepository
+
+    @Test
+    @Order(1)
+    fun `es is running`() {
+        assertThat(esContainer.isRunning).isTrue
+        service.recreateIndex()
+    }
+
+    @Test
+    @Order(2)
+    fun `index has been created by service`() {
+
+        val indexOps = esTemplate.indexOps(IndexCoordinates.of("klagebehandling"))
+        assertThat(indexOps.exists()).isTrue()
+    }
+
+    @Test
+    @Order(3)
+    fun `lagrer to oppgaver for senere tester`() {
+
+        val klagebehandling1 = EsKlagebehandling(
+            id = "1001L",
+            versjon = 1L,
+            tildeltEnhet = "4219",
+            tema = Tema.OMS.id,
+            type = Type.KLAGE.id,
+            tildeltSaksbehandlerident = null,
+            innsendt = LocalDate.of(2019, 10, 1),
+            mottattFoersteinstans = LocalDate.of(2019, 11, 1),
+            mottattKlageinstans = LocalDateTime.of(2019, 12, 1, 0, 0),
+            frist = LocalDate.of(2020, 12, 1),
+            hjemler = listOf(),
+            created = LocalDateTime.now(),
+            modified = LocalDateTime.now(),
+            kilde = "K9",
+            temaNavn = Tema.OMS.name,
+            typeNavn = Type.KLAGE.name,
+            status = IKKE_TILDELT,
+            sakenGjelderFnr = "123"
+        )
+        val klagebehandling2 =
+            EsKlagebehandling(
+                id = "1002L",
+                versjon = 1L,
+                tildeltEnhet = "4219",
+                tema = Tema.SYK.id,
+                type = Type.KLAGE.id,
+                tildeltSaksbehandlerident = null,
+                innsendt = LocalDate.of(2018, 10, 1),
+                mottattFoersteinstans = LocalDate.of(2018, 11, 1),
+                mottattKlageinstans = LocalDateTime.of(2018, 12, 1, 0, 0),
+                frist = LocalDate.of(2019, 12, 1),
+                hjemler = listOf(),
+                created = LocalDateTime.now(),
+                modified = LocalDateTime.now(),
+                kilde = "K9",
+                temaNavn = Tema.SYK.name,
+                typeNavn = Type.KLAGE.name,
+                status = IKKE_TILDELT,
+                sakenGjelderFnr = "456"
+            )
+        val klagebehandling3 = EsKlagebehandling(
+            id = "1003L",
+            versjon = 1L,
+            tildeltEnhet = "4219",
+            tema = Tema.SYK.id,
+            type = Type.KLAGE.id,
+            tildeltSaksbehandlerident = null,
+            innsendt = LocalDate.of(2019, 10, 1),
+            mottattFoersteinstans = LocalDate.of(2019, 11, 1),
+            mottattKlageinstans = LocalDateTime.of(2019, 12, 1, 0, 0),
+            frist = LocalDate.of(2020, 12, 1),
+            hjemler = listOf(),
+            created = LocalDateTime.now(),
+            modified = LocalDateTime.now(),
+            kilde = "K9",
+            temaNavn = Tema.SYK.name,
+            typeNavn = Type.KLAGE.name,
+            status = IKKE_TILDELT,
+            sakenGjelderFnr = "123"
+        )
+        val klagebehandling4 =
+            EsKlagebehandling(
+                id = "1004L",
+                versjon = 1L,
+                tildeltEnhet = "4219",
+                tema = Tema.OMS.id,
+                type = Type.KLAGE.id,
+                tildeltSaksbehandlerident = null,
+                innsendt = LocalDate.of(2018, 10, 1),
+                mottattFoersteinstans = LocalDate.of(2018, 11, 1),
+                mottattKlageinstans = LocalDateTime.of(2018, 12, 1, 0, 0),
+                frist = LocalDate.of(2019, 12, 1),
+                hjemler = listOf(),
+                created = LocalDateTime.now(),
+                modified = LocalDateTime.now(),
+                kilde = "K9",
+                temaNavn = Tema.OMS.name,
+                typeNavn = Type.KLAGE.name,
+                status = IKKE_TILDELT,
+                sakenGjelderFnr = "456"
+            )
+        repo.save(klagebehandling1)
+        repo.save(klagebehandling2)
+        repo.save(klagebehandling3)
+        repo.save(klagebehandling4)
+
+        val query: Query = NativeSearchQueryBuilder()
+            .withQuery(QueryBuilders.matchAllQuery())
+            .build()
+        val searchHits: SearchHits<EsKlagebehandling> = esTemplate.search(query, EsKlagebehandling::class.java)
+        assertThat(searchHits.totalHits).isEqualTo(4L)
+    }
+
+    @Test
+    @Order(4)
+    fun `Klagebehandling can be searched for by tema`() {
+        val klagebehandlinger: List<EsKlagebehandling> =
+            service.findByCriteria(
+                KlagebehandlingerSearchCriteria(
+                    temaer = listOf(Tema.OMS),
+                    offset = 0,
+                    limit = 10
+                )
+            ).searchHits.map { it.content }
+        assertThat(klagebehandlinger.size).isEqualTo(2L)
+        assertThat(klagebehandlinger.map { it.id }).containsExactlyInAnyOrder("1001L", "1004L")
+    }
+
+    @Test
+    @Order(4)
+    fun `Klagebehandling can be searched for by fnr and tema`() {
+        val klagebehandlinger: List<EsKlagebehandling> =
+            service.findByCriteria(
+                KlagebehandlingerSearchCriteria(
+                    temaer = listOf(Tema.OMS),
+                    foedselsnr = listOf("123"),
+                    offset = 0,
+                    limit = 10
+                )
+            ).searchHits.map { it.content }
+        assertThat(klagebehandlinger.size).isEqualTo(1L)
+        assertThat(klagebehandlinger.map { it.id }).containsExactlyInAnyOrder("1001L")
+    }
+
+    @Test
+    @Order(4)
+    fun `Klagebehandling can be searched for by ektefelle`() {
+        val klagebehandlinger: List<EsKlagebehandling> =
+            service.findByCriteria(
+                KlagebehandlingerSearchCriteria(
+                    temaer = listOf(Tema.MOB),
+                    foedselsnr = listOf("123"),
+                    extraPersonAndTema = KlagebehandlingerSearchCriteria.ExtraPersonAndTema(
+                        foedselsnr = "456",
+                        temaer = listOf(Tema.SYK)
+                    ),
+                    offset = 0,
+                    limit = 10
+                )
+            ).searchHits.map { it.content }
+        assertThat(klagebehandlinger.size).isEqualTo(1L)
+        assertThat(klagebehandlinger.map { it.id }).containsExactlyInAnyOrder("1002L")
+    }
+
+    @Test
+    @Order(4)
+    fun `Klagebehandling can be searched for by fnr and ektefelle`() {
+        val klagebehandlinger: List<EsKlagebehandling> =
+            service.findByCriteria(
+                KlagebehandlingerSearchCriteria(
+                    temaer = listOf(Tema.SYK),
+                    foedselsnr = listOf("123"),
+                    extraPersonAndTema = KlagebehandlingerSearchCriteria.ExtraPersonAndTema(
+                        foedselsnr = "456",
+                        temaer = listOf(Tema.SYK)
+                    ),
+                    offset = 0,
+                    limit = 10
+                )
+            ).searchHits.map { it.content }
+        assertThat(klagebehandlinger.size).isEqualTo(2L)
+        assertThat(klagebehandlinger.map { it.id }).containsExactlyInAnyOrder("1002L", "1003L")
+    }
+
+}


### PR DESCRIPTION
Lagt til et endepunkt for å vise relaterte klager.
Lagt til støtte for å kunne søke på en ekstra kombinasjon av fnr og tema i ES, så man kan vise klager for ektefelle og partner, men med andre tema enn det vanlige søket.