### PR TITLE
Legger til tester for eksisterende fullfør-flyt, 

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/service/VedtakService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/VedtakService.kt
@@ -221,9 +221,8 @@ class VedtakService(
         val vedtak = klagebehandling.getVedtakOrException()
         if (vedtak.ferdigstiltIJoark != null) throw VedtakFinalizedException("Vedtak med id ${vedtak.id} er allerede ferdigstilt")
 
-        if (vedtak.mellomlagerId == null && vedtak.journalpostId != null) {
-            //Dette gjelder edge-case der noen har påbegynt en klagebehandling før vi innførte mellomlager.
-            throw VedtakNotFoundException("Vennligst last opp vedtak på nytt")
+        if (vedtak.mellomlagerId == null) {
+            throw VedtakNotFoundException("Vennligst last opp vedtaksdokument på nytt")
         }
 
         if (vedtak.utfall == null) throw UtfallNotSetException("Utfall på vedtak ${vedtak.id} er ikke satt")

--- a/src/test/kotlin/no/nav/klage/oppgave/api/KlagebehandlingDetaljerControllerTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/api/KlagebehandlingDetaljerControllerTest.kt
@@ -1,0 +1,125 @@
+package no.nav.klage.oppgave.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import no.finn.unleash.Unleash
+import no.nav.klage.oppgave.api.controller.KlagebehandlingDetaljerController
+import no.nav.klage.oppgave.api.mapper.KlagebehandlingMapper
+import no.nav.klage.oppgave.api.view.KlagebehandlingMedunderskriveridentInput
+import no.nav.klage.oppgave.domain.klage.*
+import no.nav.klage.oppgave.domain.kodeverk.*
+import no.nav.klage.oppgave.repositories.InnloggetSaksbehandlerRepository
+import no.nav.klage.oppgave.service.KlagebehandlingEditableFieldsFacade
+import no.nav.klage.oppgave.service.KlagebehandlingService
+import no.nav.klage.oppgave.util.AuditLogger
+import no.nav.klage.oppgave.util.getLogger
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.put
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+@WebMvcTest(KlagebehandlingDetaljerController::class)
+@ActiveProfiles("local")
+class KlagebehandlingDetaljerControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var mapper: ObjectMapper
+
+    @MockkBean
+    lateinit var klagebehandlingService: KlagebehandlingService
+
+    @MockkBean
+    lateinit var klagebehandlingMapper: KlagebehandlingMapper
+
+    @MockkBean
+    lateinit var innloggetSaksbehandlerRepository: InnloggetSaksbehandlerRepository
+
+    @MockkBean
+    lateinit var auditLogger: AuditLogger
+
+    @MockkBean
+    lateinit var editableFieldsFacade: KlagebehandlingEditableFieldsFacade
+
+    @MockkBean
+    lateinit var unleash: Unleash
+
+    companion object {
+        @Suppress("JAVA_CLASS_ON_COMPANION")
+        private val logger = getLogger(javaClass.enclosingClass)
+    }
+
+    private val klagebehandlingId = UUID.randomUUID()
+
+    private val klagebehandling = Klagebehandling(
+        versjon = 2L,
+        klager = Klager(partId = PartId(type = PartIdType.PERSON, value = "23452354")),
+        sakenGjelder = SakenGjelder(
+            partId = PartId(type = PartIdType.PERSON, value = "23452354"),
+            skalMottaKopi = false
+        ),
+        tema = Tema.OMS,
+        type = Type.KLAGE,
+        frist = LocalDate.now(),
+        hjemler = mutableSetOf(
+            Hjemmel.FTL_8_7
+        ),
+        created = LocalDateTime.now(),
+        modified = LocalDateTime.now(),
+        mottattKlageinstans = LocalDateTime.now(),
+        kildesystem = Fagsystem.K9,
+        mottakId = UUID.randomUUID(),
+        vedtak = Vedtak(
+            utfall = Utfall.AVVIST,
+            hjemler = mutableSetOf(
+                Hjemmel.FTL
+            )
+        ),
+        medunderskriver = MedunderskriverTildeling(
+            saksbehandlerident = "C78901",
+            tidspunkt = LocalDateTime.now()
+        )
+    )
+
+    @BeforeEach
+    fun setup() {
+        every { innloggetSaksbehandlerRepository.getInnloggetIdent() } returns "B54321"
+    }
+
+    @Test
+    fun `putMedunderskriverident with correct input should return ok`() {
+        every { klagebehandlingService.setMedunderskriverIdent(any(), any(), any(), any()) } returns klagebehandling
+
+        val input = KlagebehandlingMedunderskriveridentInput(
+            "A12345",
+            1L
+        )
+
+        mockMvc.put("/klagebehandlinger/$klagebehandlingId/detaljer/medunderskriverident") {
+            contentType = MediaType.APPLICATION_JSON
+            content = mapper.writeValueAsString(input)
+            accept = MediaType.APPLICATION_JSON
+        }.andExpect {
+            status { isOk() }
+        }
+    }
+
+    @Test
+    fun `putMedunderskriverident with incorrect input should return 400 error`() {
+        mockMvc.put("/klagebehandlinger/$klagebehandlingId/detaljer/medunderskriverident") {
+        }.andExpect {
+            status { is4xxClientError() }
+        }
+    }
+
+}

--- a/src/test/kotlin/no/nav/klage/oppgave/service/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/VedtakServiceTest.kt
@@ -1,0 +1,197 @@
+package no.nav.klage.oppgave.service
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.klage.oppgave.api.view.VedtakFullfoerInput
+import no.nav.klage.oppgave.db.TestPostgresqlContainer
+import no.nav.klage.oppgave.domain.klage.*
+import no.nav.klage.oppgave.domain.kodeverk.*
+import no.nav.klage.oppgave.exceptions.MissingTilgangException
+import no.nav.klage.oppgave.exceptions.VedtakFinalizedException
+import no.nav.klage.oppgave.exceptions.VedtakNotFoundException
+import no.nav.klage.oppgave.gateway.JournalpostGateway
+import no.nav.klage.oppgave.repositories.KlagebehandlingRepository
+import no.nav.klage.oppgave.repositories.MottakRepository
+import no.nav.klage.oppgave.util.AttachmentValidator
+import no.nav.klage.oppgave.util.TokenUtil
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.test.context.ActiveProfiles
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+@ActiveProfiles("local")
+@Testcontainers
+@SpringBootTest(classes = [KlagebehandlingService::class])
+class VedtakServiceTest {
+
+    private val tilgangService: TilgangService = mockk()
+
+    @MockkBean(relaxed = true)
+    lateinit var applicationEventPublisher: ApplicationEventPublisher
+
+    @MockkBean
+    lateinit var klagebehandlingService: KlagebehandlingService
+
+    @MockkBean
+    lateinit var attachmentValidator: AttachmentValidator
+
+    @MockkBean
+    lateinit var fileApiService: FileApiService
+
+    @MockkBean
+    lateinit var journalpostGateway: JournalpostGateway
+
+//    @Autowired
+    lateinit var vedtakService: VedtakService
+
+    @BeforeEach
+    fun setup() {
+        vedtakService = VedtakService(
+            klagebehandlingService,
+            applicationEventPublisher,
+            attachmentValidator,
+            tilgangService,
+            fileApiService,
+            journalpostGateway
+        )
+    }
+
+    private val SAKSBEHANDLER_IDENT = "SAKSBEHANDLER_IDENT"
+    private val MEDUNDERSKRIVER_IDENT = "MEDUNDERSKRIVER_IDENT"
+    private val JOURNALFOERENDE_ENHET = "1234"
+    private val MELLOMLAGER_ID = "MELLOMLAGER_ID"
+    private val KLAGEBEHANDLING_ID = UUID.randomUUID()
+
+
+
+
+    @Test
+    fun `Forsøk på avslutting av vedtak fra andre enn medunderskriver skal ikke lykkes`() {
+        every { klagebehandlingService.getKlagebehandlingForUpdate(any(), any(), any()) } returns getKlageBehandling()
+        assertThrows<MissingTilgangException> {
+            vedtakService.ferdigstillVedtak(
+                KLAGEBEHANDLING_ID,
+                VedtakFullfoerInput(
+                    JOURNALFOERENDE_ENHET,
+                    1L
+                ),
+                SAKSBEHANDLER_IDENT
+            )
+        }
+    }
+
+    @Test
+    fun `Forsøk på avslutting av vedtak som allerede er ferdigstilt i Joark skal ikke lykkes`() {
+        every { klagebehandlingService.getKlagebehandlingForUpdate(any(), any(), any()) } returns getFerdigstiltKlagebehandling()
+        assertThrows<VedtakFinalizedException> {
+            vedtakService.ferdigstillVedtak(
+                KLAGEBEHANDLING_ID,
+                VedtakFullfoerInput(
+                    JOURNALFOERENDE_ENHET,
+                    1L
+                ),
+                MEDUNDERSKRIVER_IDENT
+            )
+        }
+    }
+
+    @Test
+    fun `Forsøk på avslutting av vedtak som ikke har mellomlagret dokument skal ikke lykkes`() {
+        every { klagebehandlingService.getKlagebehandlingForUpdate(any(), any(), any()) } returns getKlageBehandling()
+        assertThrows<VedtakNotFoundException> {
+            vedtakService.ferdigstillVedtak(
+                KLAGEBEHANDLING_ID,
+                VedtakFullfoerInput(
+                    JOURNALFOERENDE_ENHET,
+                    1L
+                ),
+                MEDUNDERSKRIVER_IDENT
+            )
+        }
+    }
+
+    @Test
+    fun `Forsøk på avslutting av vedtak som ikke har utfall skal ikke lykkes`() {
+        every { klagebehandlingService.getKlagebehandlingForUpdate(any(), any(), any()) } returns getKlageBehandling()
+        assertThrows<VedtakNotFoundException> {
+            vedtakService.ferdigstillVedtak(
+                KLAGEBEHANDLING_ID,
+                VedtakFullfoerInput(
+                    JOURNALFOERENDE_ENHET,
+                    1L
+                ),
+                MEDUNDERSKRIVER_IDENT
+            )
+        }
+    }
+
+    @Test
+    fun `Forsøk på avslutting av vedtak som er riktig utfylt skal lykkes`() {
+        every { klagebehandlingService.getKlagebehandlingForUpdate(any(), any(), any()) } returns getKlagebehandlingMedUtfall()
+        every { klagebehandlingService.markerKlagebehandlingSomAvsluttetAvSaksbehandler(any(), any()) } returns getKlagebehandlingMedUtfall()
+        val result = vedtakService.ferdigstillVedtak(
+                KLAGEBEHANDLING_ID,
+                VedtakFullfoerInput(
+                    JOURNALFOERENDE_ENHET,
+                    1L
+                ),
+                MEDUNDERSKRIVER_IDENT
+            )
+        assert(result.getVedtakOrException().avsluttetAvSaksbehandler != null)
+    }
+
+    private fun getKlageBehandling(): Klagebehandling {
+        return Klagebehandling(
+            versjon = 2L,
+            klager = Klager(partId = PartId(type = PartIdType.PERSON, value = "23452354")),
+            sakenGjelder = SakenGjelder(
+                partId = PartId(type = PartIdType.PERSON, value = "23452354"),
+                skalMottaKopi = false
+            ),
+            tema = Tema.OMS,
+            type = Type.KLAGE,
+            frist = LocalDate.now(),
+            hjemler = mutableSetOf(
+                Hjemmel.FTL_8_7
+            ),
+            created = LocalDateTime.now(),
+            modified = LocalDateTime.now(),
+            mottattKlageinstans = LocalDateTime.now(),
+            kildesystem = Fagsystem.K9,
+            mottakId = UUID.randomUUID(),
+            vedtak = Vedtak(
+                hjemler = mutableSetOf(
+                    Hjemmel.FTL
+                )
+            ),
+            medunderskriver = MedunderskriverTildeling(
+                MEDUNDERSKRIVER_IDENT,
+                LocalDateTime.now()
+            )
+        )
+    }
+
+    private fun getFerdigstiltKlagebehandling(): Klagebehandling {
+        return getKlageBehandling().apply { getVedtakOrException().ferdigstiltIJoark = LocalDateTime.now() }
+    }
+
+    private fun getKlagebehandlingMedUtfall(): Klagebehandling {
+        return getKlageBehandling().apply {
+            getVedtakOrException().utfall = Utfall.AVVIST
+            getVedtakOrException().mellomlagerId = MELLOMLAGER_ID
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/klage/oppgave/service/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/VedtakServiceTest.kt
@@ -2,31 +2,20 @@ package no.nav.klage.oppgave.service
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
-import io.mockk.mockk
 import no.nav.klage.oppgave.api.view.VedtakFullfoerInput
-import no.nav.klage.oppgave.db.TestPostgresqlContainer
 import no.nav.klage.oppgave.domain.klage.*
 import no.nav.klage.oppgave.domain.kodeverk.*
 import no.nav.klage.oppgave.exceptions.MissingTilgangException
 import no.nav.klage.oppgave.exceptions.VedtakFinalizedException
 import no.nav.klage.oppgave.exceptions.VedtakNotFoundException
 import no.nav.klage.oppgave.gateway.JournalpostGateway
-import no.nav.klage.oppgave.repositories.KlagebehandlingRepository
-import no.nav.klage.oppgave.repositories.MottakRepository
 import no.nav.klage.oppgave.util.AttachmentValidator
-import no.nav.klage.oppgave.util.TokenUtil
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.test.context.ActiveProfiles
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -37,7 +26,8 @@ import java.util.*
 @SpringBootTest(classes = [KlagebehandlingService::class])
 class VedtakServiceTest {
 
-    private val tilgangService: TilgangService = mockk()
+    @MockkBean
+    lateinit var tilgangService: TilgangService
 
     @MockkBean(relaxed = true)
     lateinit var applicationEventPublisher: ApplicationEventPublisher
@@ -54,7 +44,6 @@ class VedtakServiceTest {
     @MockkBean
     lateinit var journalpostGateway: JournalpostGateway
 
-//    @Autowired
     lateinit var vedtakService: VedtakService
 
     @BeforeEach
@@ -76,8 +65,6 @@ class VedtakServiceTest {
     private val KLAGEBEHANDLING_ID = UUID.randomUUID()
 
 
-
-
     @Test
     fun `Forsøk på avslutting av vedtak fra andre enn medunderskriver skal ikke lykkes`() {
         every { klagebehandlingService.getKlagebehandlingForUpdate(any(), any(), any()) } returns getKlageBehandling()
@@ -95,7 +82,13 @@ class VedtakServiceTest {
 
     @Test
     fun `Forsøk på avslutting av vedtak som allerede er ferdigstilt i Joark skal ikke lykkes`() {
-        every { klagebehandlingService.getKlagebehandlingForUpdate(any(), any(), any()) } returns getFerdigstiltKlagebehandling()
+        every {
+            klagebehandlingService.getKlagebehandlingForUpdate(
+                any(),
+                any(),
+                any()
+            )
+        } returns getFerdigstiltKlagebehandling()
         assertThrows<VedtakFinalizedException> {
             vedtakService.ferdigstillVedtak(
                 KLAGEBEHANDLING_ID,
@@ -140,16 +133,27 @@ class VedtakServiceTest {
 
     @Test
     fun `Forsøk på avslutting av vedtak som er riktig utfylt skal lykkes`() {
-        every { klagebehandlingService.getKlagebehandlingForUpdate(any(), any(), any()) } returns getKlagebehandlingMedUtfall()
-        every { klagebehandlingService.markerKlagebehandlingSomAvsluttetAvSaksbehandler(any(), any()) } returns getKlagebehandlingMedUtfall()
-        val result = vedtakService.ferdigstillVedtak(
-                KLAGEBEHANDLING_ID,
-                VedtakFullfoerInput(
-                    JOURNALFOERENDE_ENHET,
-                    1L
-                ),
-                MEDUNDERSKRIVER_IDENT
+        every {
+            klagebehandlingService.getKlagebehandlingForUpdate(
+                any(),
+                any(),
+                any()
             )
+        } returns getKlagebehandlingMedUtfall()
+        every {
+            klagebehandlingService.markerKlagebehandlingSomAvsluttetAvSaksbehandler(
+                any(),
+                any()
+            )
+        } returns getKlagebehandlingMedUtfall()
+        val result = vedtakService.ferdigstillVedtak(
+            KLAGEBEHANDLING_ID,
+            VedtakFullfoerInput(
+                JOURNALFOERENDE_ENHET,
+                1L
+            ),
+            MEDUNDERSKRIVER_IDENT
+        )
         assert(result.getVedtakOrException().avsluttetAvSaksbehandler != null)
     }
 


### PR DESCRIPTION
for å sikre at endring på medunderskriver-flyten ikke påvirker denne.

Sjekken på mellomlagerid i VedtakService slapp for mye igjennom, det er nå krav om at vedtak fins i mellomlageret for å avslutte klagebehandlingen.