### PR TITLE
Forsøk på mer logging for å finne flaskehalser

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/filter/TimingFilter.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/filter/TimingFilter.kt
@@ -1,0 +1,41 @@
+package no.nav.klage.oppgave.api.filter
+
+import no.nav.klage.oppgave.util.getLogger
+import org.springframework.stereotype.Component
+import java.io.IOException
+import java.time.Duration
+import java.time.Instant
+import javax.servlet.*
+import javax.servlet.annotation.WebFilter
+import javax.servlet.http.HttpServletRequest
+
+
+@Component
+@WebFilter("/klagebehandlinger/*")
+class TimingFilter : Filter {
+
+    companion object {
+        private val logger = getLogger(javaClass.enclosingClass)
+    }
+
+    @Throws(ServletException::class)
+    override fun init(filterConfig: FilterConfig) {
+        // empty
+    }
+
+    @Throws(IOException::class, ServletException::class)
+    override fun doFilter(req: ServletRequest, resp: ServletResponse, chain: FilterChain) {
+        val start = Instant.now()
+        try {
+            chain.doFilter(req, resp)
+        } finally {
+            val finish = Instant.now()
+            val time = Duration.between(start, finish).toMillis()
+            logger.debug("{}: {} ms ", (req as HttpServletRequest).requestURI, time)
+        }
+    }
+
+    override fun destroy() {
+        // empty
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,13 @@ spring:
         enabled: false
   jpa:
     open-in-view: false
+    properties:
+      hibernate.session.events.log.LOG_QUERIES_SLOWER_THAN_MS: 20
+      hibernate:
+        session:
+          events:
+            log:
+              LOG_QUERIES_SLOWER_THAN_MS: 20
   lifecycle:
     timeout-per-shutdown-phase: 20s
   servlet:
@@ -56,6 +63,10 @@ spring:
     max-in-memory-size: 16MB
 
 maxAttachmentSize: 8MB
+
+org:
+  hibernate:
+    SQL_SLOW: info
 
 server:
   port: 7081

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -86,6 +86,11 @@
                 level="warning"/>
 
         <logger name="io.micrometer.influx" level="debug"/>
+
+        <logger name="org.hibernate.SQL" level="debug"/>
+        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="debug"/>
+        <logger name="org.hibernate.SQL_SLOW" level="debug"/>
+
     </springProfile>
 
     <logger name="no.nav.klage" level="debug"/>


### PR DESCRIPTION
Lagt til støtte for å logge hvor lang tid requester til /klagebehandlinger tar, samt sql statements