### PR TITLE
Endret saf scope fra clientId til azureator.

### DIFF
--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -26,7 +26,7 @@ AIVEN_ES_SCHEME: https
 AIVEN_ES_USE_SSL: true
 
 SAF_BASE_URL: https://saf.dev-fss-pub.nais.io/
-SAF_APP_CLIENT_ID: c7adbfbb-1b1e-41f6-9b7a-af9627c04998
+SAF_APP_CLIENT_ID: dev-fss.teamdokumenthandtering.saf
 
 DOKARKIV_CLIENT_ID: 972814f3-8bdf-44f8-a191-c2ed00020b54
 

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -26,7 +26,7 @@ AIVEN_ES_SCHEME: https
 AIVEN_ES_USE_SSL: true
 
 SAF_BASE_URL: https://saf.prod-fss-pub.nais.io/
-SAF_APP_CLIENT_ID: feb9588b-a3d6-4d2f-8809-97284046ae72
+SAF_APP_CLIENT_ID: prod-fss.teamdokumenthandtering.saf
 
 DOKARKIV_CLIENT_ID: 162b3255-2f72-4399-8f7a-244add9ffaac
 


### PR DESCRIPTION
Saf har migrert fra aad-iac til azureator. 

ClientId kan endre seg hvis vi av en eller annen grunn må slette nåværende azureator config. Denne endringen vil redusere risiko for at saf klienten deres feiler pga det som er nevnt.

Ta gjerne noen testkall i dev før dere går til prod.