### PR TITLE
Endringer i StatistikkTilDVHEventListener

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/eventlisteners/StatistikkTilDVHEventListener.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/eventlisteners/StatistikkTilDVHEventListener.kt
@@ -3,10 +3,7 @@ package no.nav.klage.oppgave.eventlisteners
 import no.nav.klage.oppgave.domain.events.KlagebehandlingEndretEvent
 import no.nav.klage.oppgave.util.getLogger
 import org.springframework.context.event.EventListener
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
 
 @Service
 class StatistikkTilDVHEventListener(private val statistikkTilDVHService: StatistikkTilDVHService) {
@@ -15,10 +12,8 @@ class StatistikkTilDVHEventListener(private val statistikkTilDVHService: Statist
         @Suppress("JAVA_CLASS_ON_COMPANION")
         private val logger = getLogger(javaClass.enclosingClass)
     }
-
-    @Async
+    
     @EventListener
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun klagebehandlingEndretEventToDVH(klagebehandlingEndretEvent: KlagebehandlingEndretEvent) {
         logger.debug("Received KlagebehandlingEndretEvent for klagebehandlingId ${klagebehandlingEndretEvent.klagebehandling.id} in StatistikkTilDVHEventListener")
         statistikkTilDVHService.process(klagebehandlingEndretEvent)

--- a/src/main/kotlin/no/nav/klage/oppgave/eventlisteners/StatistikkTilDVHService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/eventlisteners/StatistikkTilDVHService.kt
@@ -33,11 +33,10 @@ class StatistikkTilDVHService(
     }
 
     fun process(klagebehandlingEndretEvent: KlagebehandlingEndretEvent) {
-        val klagebehandling = klagebehandlingEndretEvent.klagebehandling
-
-        val mottak = mottakRepository.getOne(klagebehandling.mottakId)
-
         if (shouldSendStats(klagebehandlingEndretEvent.endringslogginnslag)) {
+
+            val klagebehandling = klagebehandlingEndretEvent.klagebehandling
+            val mottak = mottakRepository.getOne(klagebehandling.mottakId)
             val eventId = UUID.randomUUID()
 
             val klageStatistikkTilDVH = createKlageStatistikkTilDVH(


### PR DESCRIPTION
Litt av greia med outbox-patternet (store-and-forward), er at man ikke trenger distribuerte transaksjoner. Det er enklere (mulig!) å holde i sync de lokale endringene du selv gjør med meldingen du skal sende ut på Kafka, fordi man lagrer meldingen i outboxen i samme transaksjon som man lagrer det andre man har gjort. 
Men det ser jeg at ikke er tilfelle for oss. Koden vår i StatistikkTilDVHEventListener er annotert til å kjøre async og *etter* at hovedtransaksjonen er commited. Dette ga jo mening før, men kanskje ikke nå lenger? Så her er en PR for å endre det.

Iom at dette nå da vil kalles hver eneste gang vi oppdaterer en klagebehandling, så flyttet jeg bruken av if (shouldSendStats(...)) øverste i process-metoden, så vi slipper å hente Mottak unødvendig.