### PR TITLE
Lagt til endepunkt for å slå opp medunderskrivere basert på ytelse

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/SaksbehandlerController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/SaksbehandlerController.kt
@@ -158,9 +158,9 @@ class SaksbehandlerController(
     )
     @GetMapping("/medunderskrivere/ytelser/{ytelse}/enheter/{enhet}/ansatte/{navIdent}", produces = ["application/json"])
     fun getMedunderskrivereForYtelse(
-        @ApiParam(value = "Ytelse man trenger medunderskrivere for")
+        @ApiParam(value = "Id for ytelse man trenger medunderskrivere for")
         @PathVariable ytelse: String,
-        @ApiParam(value = "Enhet saksbehandleren man skal finne medunderskriver til jobber i")
+        @ApiParam(value = "Enhetsnr for enhet saksbehandleren man skal finne medunderskriver til jobber i")
         @PathVariable enhet: String,
         @ApiParam(value = "NavIdent til saksbehandleren man skal finne medunderskriver til")
         @PathVariable navIdent: String,

--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/SaksbehandlerController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/SaksbehandlerController.kt
@@ -160,9 +160,9 @@ class SaksbehandlerController(
     fun getMedunderskrivereForYtelse(
         @ApiParam(value = "Ytelse man trenger medunderskrivere for")
         @PathVariable ytelse: String,
-        @ApiParam(value = "Enhet man saksbehandleren jobber i")
+        @ApiParam(value = "Enhet saksbehandleren man skal finne medunderskriver til jobber i")
         @PathVariable enhet: String,
-        @ApiParam(value = "NavIdent til saksbehandleren")
+        @ApiParam(value = "NavIdent til saksbehandleren man skal finne medunderskriver til")
         @PathVariable navIdent: String,
     ): Medunderskrivere {
         logger.debug("getMedunderskrivereForYtelse is requested by $navIdent")

--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/SaksbehandlerController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/SaksbehandlerController.kt
@@ -8,6 +8,7 @@ import no.nav.klage.oppgave.api.mapper.mapToView
 import no.nav.klage.oppgave.api.view.*
 import no.nav.klage.oppgave.config.SecurityConfiguration
 import no.nav.klage.oppgave.domain.kodeverk.Tema
+import no.nav.klage.oppgave.domain.kodeverk.Ytelse
 import no.nav.klage.oppgave.exceptions.NotMatchingUserException
 import no.nav.klage.oppgave.repositories.InnloggetSaksbehandlerRepository
 import no.nav.klage.oppgave.service.SaksbehandlerService
@@ -138,8 +139,39 @@ class SaksbehandlerController(
         return if (environment.activeProfiles.contains("prod-gcp")) {
             saksbehandlerService.getMedunderskrivere(navIdent, Tema.of(tema))
         } else Medunderskrivere(
-            tema,
-            listOf(
+            tema = tema,
+            ytelse = null,
+            medunderskrivere = listOf(
+                Medunderskriver("Z994488", "F_Z994488, E_Z994488"),
+                Medunderskriver("Z994330", "F_Z994330 E_Z994330"),
+                Medunderskriver("Z994861", "F_Z994861 E_Z994861"),
+                Medunderskriver("Z994864", "F_Z994864 E_Z994864"),
+                Medunderskriver("Z994863", "F_Z994863 E_Z994863"),
+                Medunderskriver("Z994862", "F_Z994862 E_Z994862"),
+            ).filter { it.ident != navIdent }
+        )
+    }
+
+    @ApiOperation(
+        value = "Hent medunderskriver for en ansatt",
+        notes = "Henter alle medunderskrivere som saksbehandler er knyttet til for en gitt ytelse."
+    )
+    @GetMapping("/medunderskrivere/ytelser/{ytelse}/enheter/{enhet}/ansatte/{navIdent}", produces = ["application/json"])
+    fun getMedunderskrivereForYtelse(
+        @ApiParam(value = "Ytelse man trenger medunderskrivere for")
+        @PathVariable ytelse: String,
+        @ApiParam(value = "Enhet man saksbehandleren jobber i")
+        @PathVariable enhet: String,
+        @ApiParam(value = "NavIdent til saksbehandleren")
+        @PathVariable navIdent: String,
+    ): Medunderskrivere {
+        logger.debug("getMedunderskrivereForYtelse is requested by $navIdent")
+        return if (environment.activeProfiles.contains("prod-gcp")) {
+            saksbehandlerService.getMedunderskrivere(navIdent, enhet, Ytelse.of(ytelse))
+        } else Medunderskrivere(
+            tema = null,
+            ytelse = ytelse,
+            medunderskrivere = listOf(
                 Medunderskriver("Z994488", "F_Z994488, E_Z994488"),
                 Medunderskriver("Z994330", "F_Z994330 E_Z994330"),
                 Medunderskriver("Z994861", "F_Z994861 E_Z994861"),

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/Medunderskriver.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/Medunderskriver.kt
@@ -1,5 +1,5 @@
 package no.nav.klage.oppgave.api.view
 
-data class Medunderskrivere(val tema: String, val medunderskrivere: List<Medunderskriver>)
+data class Medunderskrivere(val tema: String?, val ytelse: String?, val medunderskrivere: List<Medunderskriver>)
 
 data class Medunderskriver(val ident: String, val navn: String)

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/Saksbehandlertildeling.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/Saksbehandlertildeling.kt
@@ -2,5 +2,5 @@ package no.nav.klage.oppgave.api.view
 
 data class Saksbehandlertildeling(
     val navIdent: String,
-    val enhetId: String?,
+    val enhetId: String,
 )

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/kodeverk/Ytelse.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/kodeverk/Ytelse.kt
@@ -13,7 +13,6 @@ enum class Ytelse(override val id: String, override val navn: String, override v
     SYK_SYK("5", "Sykepenger", "Sykepenger")
     ;
 
-
     companion object {
         fun of(id: String): Ytelse {
             return values().firstOrNull { it.id == id }
@@ -28,6 +27,23 @@ enum class Ytelse(override val id: String, override val navn: String, override v
         }
     }
 }
+
+val ytelserPerEnhet = mapOf(
+    "4203" to listOf(Ytelse.SYK_SYK),
+    "4205" to listOf(Ytelse.SYK_SYK),
+    "4207" to listOf(),
+    "4214" to listOf(Ytelse.SYK_SYK),
+    "4219" to listOf(Ytelse.OMS_OMP, Ytelse.OMS_PLS, Ytelse.OMS_PSB, Ytelse.OMS_OLP),
+    "4250" to listOf(),
+)
+
+val enheterPerYtelse = mapOf(
+    Ytelse.SYK_SYK to listOf("4203", "4205", "4214"),
+    Ytelse.OMS_OMP to listOf("4219"),
+    Ytelse.OMS_PLS to listOf("4219"),
+    Ytelse.OMS_PSB to listOf("4219"),
+    Ytelse.OMS_OLP to listOf("4219"),
+)
 
 object LovligeYtelser {
     private val lovligeYtelserIProdGcp = EnumSet.of(Ytelse.OMS_OMP, Ytelse.OMS_OLP, Ytelse.OMS_PSB, Ytelse.OMS_PLS)


### PR DESCRIPTION
Jeg har ikke fjernet endepunktet for tema, så det er fremdeles operativt.
Det nye endepunktet for ytelse har fått en litt annen URL, den ser nå ut som dette:
`/medunderskrivere/ytelser/{ytelse}/enheter/{enhet}/ansatte/{navIdent}`
Den gamle med tema var
`/ansatte/{navIdent}/medunderskrivere/{tema}`
Tanken er at vi kan trenge enhet i tillegg til ytelse, ref diskusjon på slack:
https://nav-it.slack.com/archives/C02K9CB309J/p1637675163034000
(og tilhørende poster over og under)

Jeg har ikke laget koden for å sortere medunderskriverne i riktig rekkefølge basert på enhet, det får komme senere. Men med den nye URLen så blir det iallefall mulig.

Vi lagrer forøvrig ikke enhetId for medunderskriver ser jeg, bare ident. Så sånn sett så er det egentlig ingen som vet hvilken enhet medunderskriver jobber i, så dette er kun et visnings-issue i forbindelse med dropdownen når de skal velge medunderskriver.
