### PR TITLE
Lagt til kode for å hente ut enheten saksbehandler er ansatt i fra Azure

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
 
     implementation("org.redundent:kotlin-xml-builder:$kotlinXmlBuilderVersion")
 
-    implementation("com.github.navikt:kabal-kodeverk:2022.01.04-14.46.3a9e323d3b93")
+    implementation("com.github.navikt:kabal-kodeverk:2022.01.07-07.15.3ce71c11b311")
 
     implementation("no.nav.security:token-validation-spring:$tokenValidationVersion")
     implementation("no.nav.security:token-client-spring:$tokenValidationVersion")

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/azure/DefaultAzureGateway.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/azure/DefaultAzureGateway.kt
@@ -95,7 +95,7 @@ class DefaultAzureGateway(private val microsoftGraphClient: MicrosoftGraphClient
         }
 
     private fun mapToEnhet(enhetNr: String): Enhet =
-        KodeverkEnhet.values().find { it.name == enhetNr }
+        KodeverkEnhet.values().find { it.navn == enhetNr }
             ?.let { Enhet(it.navn, it.beskrivelse) }
             ?: throw EnhetNotFoundForSaksbehandlerException("Enhet ikke funnet med enhetNr $enhetNr")
 

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/azure/DefaultAzureGateway.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/azure/DefaultAzureGateway.kt
@@ -1,11 +1,14 @@
 package no.nav.klage.oppgave.clients.azure
 
+import no.nav.klage.oppgave.domain.saksbehandler.Enhet
 import no.nav.klage.oppgave.domain.saksbehandler.SaksbehandlerPersonligInfo
 import no.nav.klage.oppgave.domain.saksbehandler.SaksbehandlerRolle
+import no.nav.klage.oppgave.exceptions.EnhetNotFoundForSaksbehandlerException
 import no.nav.klage.oppgave.gateway.AzureGateway
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.klage.oppgave.util.getSecureLogger
 import org.springframework.stereotype.Service
+import no.nav.klage.kodeverk.Enhet as KodeverkEnhet
 
 @Service
 class DefaultAzureGateway(private val microsoftGraphClient: MicrosoftGraphClient) : AzureGateway {
@@ -49,7 +52,8 @@ class DefaultAzureGateway(private val microsoftGraphClient: MicrosoftGraphClient
             data.givenName,
             data.surname,
             data.displayName,
-            data.mail
+            data.mail,
+            mapToEnhet(data.streetAddress),
         )
     }
 
@@ -66,7 +70,8 @@ class DefaultAzureGateway(private val microsoftGraphClient: MicrosoftGraphClient
             data.givenName,
             data.surname,
             data.displayName,
-            data.mail
+            data.mail,
+            mapToEnhet(data.streetAddress),
         )
     }
 
@@ -89,5 +94,9 @@ class DefaultAzureGateway(private val microsoftGraphClient: MicrosoftGraphClient
             throw e
         }
 
+    private fun mapToEnhet(enhetNr: String): Enhet =
+        KodeverkEnhet.values().find { it.name == enhetNr }
+            ?.let { Enhet(it.navn, it.beskrivelse) }
+            ?: throw EnhetNotFoundForSaksbehandlerException("Enhet ikke funnet med enhetNr $enhetNr")
 
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/azure/MicrosoftGraphClient.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/azure/MicrosoftGraphClient.kt
@@ -25,7 +25,7 @@ class MicrosoftGraphClient(
         private val secureLogger = getSecureLogger()
 
         private const val userSelect =
-            "onPremisesSamAccountName,displayName,givenName,surname,mail,officeLocation,userPrincipalName,id,jobTitle"
+            "onPremisesSamAccountName,displayName,givenName,surname,mail,officeLocation,userPrincipalName,id,jobTitle,streetAddress"
 
         private const val slimUserSelect = "userPrincipalName,onPremisesSamAccountName,displayName"
 

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/azure/MicrosoftGraphResponse.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/azure/MicrosoftGraphResponse.kt
@@ -12,7 +12,8 @@ data class AzureUser(
     val officeLocation: String?,
     val userPrincipalName: String,
     val id: String,
-    val jobTitle: String?
+    val jobTitle: String?,
+    val streetAddress: String,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/no/nav/klage/oppgave/config/problem/ProblemHandlingControllerAdvice.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/config/problem/ProblemHandlingControllerAdvice.kt
@@ -122,7 +122,10 @@ interface OurOwnExceptionAdviceTrait : AdviceTrait {
         create(ex, createProblem(ex), request)
 
     @ExceptionHandler
-    fun handleDuplicateOversendelse(ex: DuplicateOversendelseException, request: NativeWebRequest): ResponseEntity<Problem> =
+    fun handleDuplicateOversendelse(
+        ex: DuplicateOversendelseException,
+        request: NativeWebRequest
+    ): ResponseEntity<Problem> =
         create(Status.CONFLICT, ex, request)
 
     @ExceptionHandler
@@ -147,11 +150,19 @@ interface OurOwnExceptionAdviceTrait : AdviceTrait {
         create(Status.NOT_FOUND, ex, request)
 
     @ExceptionHandler
+    fun handleEnhetNotFoundForSaksbehandlerException(
+        ex: EnhetNotFoundForSaksbehandlerException,
+        request: NativeWebRequest
+    ): ResponseEntity<Problem> =
+        create(Status.INTERNAL_SERVER_ERROR, ex, request)
+
+    @ExceptionHandler
     fun handleSectionedValidationErrorWithDetailsException(
         ex: SectionedValidationErrorWithDetailsException,
         request: NativeWebRequest
     ): ResponseEntity<Problem> =
         create(ex, createSectionedValidationProblem(ex), request)
+
 
     private fun createProblem(ex: WebClientResponseException): ThrowableProblem {
         return Problem.builder()

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/saksbehandler/SaksbehandlerPersonligInfo.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/saksbehandler/SaksbehandlerPersonligInfo.kt
@@ -6,5 +6,6 @@ data class SaksbehandlerPersonligInfo(
     val fornavn: String,
     val etternavn: String,
     val sammensattNavn: String,
-    val epost: String
+    val epost: String,
+    val enhet: Enhet,
 )

--- a/src/main/kotlin/no/nav/klage/oppgave/exceptions/Exceptions.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/exceptions/Exceptions.kt
@@ -55,3 +55,5 @@ class KlagebehandlingSamtidigEndretException(msg: String) : RuntimeException(msg
 class KlagebehandlingAvsluttetException(msg: String) : RuntimeException(msg)
 
 class KlagebehandlingManglerMedunderskriverException(msg: String) : RuntimeException(msg)
+
+class EnhetNotFoundForSaksbehandlerException(msg: String) : RuntimeException(msg)


### PR DESCRIPTION
(Koden er testet i dev, og den fungerer. Men testbrukerne våre tilhører et kontor vi ikke har (NAV IKT DRIFT), så vi må få endret på det før dette kan merges.

Punkt til diskusjon: Jeg bruker her i kabal ikke kode-enumen vår, men domeneklassen vi hadde fra før og bruker andre steder. Jeg tenker at skal vi endre til enumen så bør vi gjøre det over hele fjøla, ikke bare akkurat her.