### PR TITLE
Små tweaks for å forhindre Colima-problemer

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ spring:
     enabled: true
     clean-on-validation-error: false
     schemas: flyway_history_schema,klage
+    connect-retries: 2
   jpa:
     open-in-view: false
     properties:

--- a/src/test/kotlin/no/nav/klage/oppgave/db/TestPostgresqlContainer.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/db/TestPostgresqlContainer.kt
@@ -1,6 +1,7 @@
 package no.nav.klage.oppgave.db
 
 import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
 
 class TestPostgresqlContainer private constructor() :
     PostgreSQLContainer<TestPostgresqlContainer?>(IMAGE_VERSION) {
@@ -8,7 +9,7 @@ class TestPostgresqlContainer private constructor() :
     companion object {
         private const val IMAGE_VERSION = "postgres:12.6"
 
-        private val CONTAINER: TestPostgresqlContainer = TestPostgresqlContainer()
+        private val CONTAINER: TestPostgresqlContainer = TestPostgresqlContainer().waitingFor(HostPortWaitStrategy())!!
 
         val instance: TestPostgresqlContainer
             get() {


### PR DESCRIPTION
Det hender jeg får connection problemer i testene (mot Postgres) etter overgangen til Colima. Disse to endringene er ting andre i Nav har gjort for å bli kvitt det problemet.