### PR TITLE
No need for protection for this sse-endpoint

### DIFF
--- a/src/main/kotlin/no/nav/klage/dokument/api/controller/DokumenterUnderArbeidController.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/api/controller/DokumenterUnderArbeidController.kt
@@ -15,6 +15,7 @@ import no.nav.klage.oppgave.repositories.InnloggetSaksbehandlerRepository
 import no.nav.klage.oppgave.service.BehandlingService
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -199,7 +200,7 @@ class DokumentUnderArbeidController(
         )
     }
 
-
+    @Unprotected
     @GetMapping("/events")
     fun documentEvents(
         @PathVariable("behandlingId") behandlingId: UUID,

--- a/src/main/kotlin/no/nav/klage/dokument/api/controller/DokumenterUnderArbeidController.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/api/controller/DokumenterUnderArbeidController.kt
@@ -209,9 +209,6 @@ class DokumentUnderArbeidController(
     ): SseEmitter {
         logger.debug("Kall mottatt på documentEvents for behandlingId $behandlingId")
 
-        //Sjekker tilgang på behandlingsnivå
-        behandlingService.getBehandling(behandlingId)
-
         val emitter = SseEmitter(Duration.ofHours(20).toMillis())
 
         val initial = SseEmitter.event()


### PR DESCRIPTION
Alt som eksponeres her er UUID til dokumenter som blir ferdigstilte for en gitt behandling-UUID.