### PR TITLE
Avoid dvh stats when dealing with Fagsystem IT01.

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/eventlisteners/StatistikkTilDVHService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/eventlisteners/StatistikkTilDVHService.kt
@@ -60,13 +60,17 @@ class StatistikkTilDVHService(
 
     private fun StatistikkTilDVH.toJson(): String = objectMapper.writeValueAsString(this)
 
-    private fun shouldSendStats(behandlingEndretEvent: BehandlingEndretEvent) =
-        behandlingEndretEvent.behandling.fagsystem != Fagsystem.IT01 && (behandlingEndretEvent.endringslogginnslag.isEmpty() && behandlingEndretEvent.behandling.type != Type.ANKE_I_TRYGDERETTEN) ||
-                behandlingEndretEvent.endringslogginnslag.any {
-                    it.felt === Felt.TILDELT_SAKSBEHANDLERIDENT
-                            || it.felt === Felt.AVSLUTTET_AV_SAKSBEHANDLER
-                            || it.felt === Felt.KJENNELSE_MOTTATT
-                }
+    fun shouldSendStats(behandlingEndretEvent: BehandlingEndretEvent): Boolean {
+        return if (behandlingEndretEvent.behandling.fagsystem == Fagsystem.IT01) {
+            false
+        } else if (behandlingEndretEvent.endringslogginnslag.isEmpty() && behandlingEndretEvent.behandling.type != Type.ANKE_I_TRYGDERETTEN) {
+            true
+        } else behandlingEndretEvent.endringslogginnslag.any {
+            it.felt === Felt.TILDELT_SAKSBEHANDLERIDENT
+                    || it.felt === Felt.AVSLUTTET_AV_SAKSBEHANDLER
+                    || it.felt === Felt.KJENNELSE_MOTTATT
+        }
+    }
 
     private fun getBehandlingState(behandlingEndretEvent: BehandlingEndretEvent): BehandlingState {
         val endringslogginnslag: List<Endringslogginnslag> = behandlingEndretEvent.endringslogginnslag

--- a/src/main/resources/db/migration/V67__Remove_it01_to_dvh:in_kafka_events.sql
+++ b/src/main/resources/db/migration/V67__Remove_it01_to_dvh:in_kafka_events.sql
@@ -1,0 +1,4 @@
+DELETE
+FROM klage.kafka_event
+WHERE type = 'STATS_DVH'
+  AND kafka_event.kilde = 'IT01'

--- a/src/main/resources/db/migration/V67__Remove_it01_to_dvh_in_kafka_events.sql
+++ b/src/main/resources/db/migration/V67__Remove_it01_to_dvh_in_kafka_events.sql
@@ -1,4 +1,4 @@
 DELETE
 FROM klage.kafka_event
 WHERE type = 'STATS_DVH'
-  AND kafka_event.kilde = 'IT01'
+  AND kafka_event.kilde = 'IT01';

--- a/src/test/kotlin/no/nav/klage/oppgave/eventlisteners/StatistikkTilDVHServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/eventlisteners/StatistikkTilDVHServiceTest.kt
@@ -1,0 +1,274 @@
+package no.nav.klage.oppgave.eventlisteners
+
+import io.mockk.mockk
+import no.nav.klage.kodeverk.Fagsystem
+import no.nav.klage.kodeverk.PartIdType
+import no.nav.klage.kodeverk.Type
+import no.nav.klage.kodeverk.Ytelse
+import no.nav.klage.oppgave.domain.events.BehandlingEndretEvent
+import no.nav.klage.oppgave.domain.klage.*
+import no.nav.klage.oppgave.repositories.KafkaEventRepository
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+class StatistikkTilDVHServiceTest {
+
+    private val kafkaEventRepository: KafkaEventRepository = mockk()
+
+    private val statistikkTilDVHService = StatistikkTilDVHService(
+        kafkaEventRepository = kafkaEventRepository
+
+    )
+
+
+    @Test
+    fun `shouldSendStats new behandling`() {
+
+        val klagebehandlingEndretEvent = BehandlingEndretEvent(
+            behandling = klagebehandlingOMP,
+            endringslogginnslag = listOf()
+        )
+
+        val ankebehandlingEndretEvent = BehandlingEndretEvent(
+            behandling = ankebehandlingOMP,
+            endringslogginnslag = listOf()
+        )
+
+        val ankeITrygderettenbehandlingEndretEvent = BehandlingEndretEvent(
+            behandling = ankeITrygderettenbehandlingOMP,
+            endringslogginnslag = listOf()
+        )
+
+        assertTrue(statistikkTilDVHService.shouldSendStats(klagebehandlingEndretEvent))
+        assertTrue(statistikkTilDVHService.shouldSendStats(ankebehandlingEndretEvent))
+        assertFalse(statistikkTilDVHService.shouldSendStats(ankeITrygderettenbehandlingEndretEvent))
+    }
+
+    @Test
+    fun `shouldSendStats existing behandling`() {
+
+        val klagebehandlingEndretEvent = BehandlingEndretEvent(
+            behandling = klagebehandlingOMP,
+            endringslogginnslag = listOf(
+                Endringslogginnslag(
+                    saksbehandlerident = null,
+                    kilde = KildeSystem.KABAL,
+                    handling = Handling.ENDRING,
+                    felt = Felt.TILDELT_SAKSBEHANDLERIDENT,
+                    behandlingId = UUID.randomUUID(),
+                    tidspunkt = LocalDateTime.now(),
+                    fraVerdi = null,
+                    tilVerdi = null,
+                )
+            )
+        )
+
+        val klagebehandlingHJEEndretEvent = BehandlingEndretEvent(
+            behandling = klagebehandlingHJE,
+            endringslogginnslag = listOf(
+                Endringslogginnslag(
+                    saksbehandlerident = null,
+                    kilde = KildeSystem.KABAL,
+                    handling = Handling.ENDRING,
+                    felt = Felt.TILDELT_SAKSBEHANDLERIDENT,
+                    behandlingId = UUID.randomUUID(),
+                    tidspunkt = LocalDateTime.now(),
+                    fraVerdi = null,
+                    tilVerdi = null,
+                )
+            )
+        )
+
+        val ankebehandlingEndretEvent = BehandlingEndretEvent(
+            behandling = ankebehandlingOMP,
+            endringslogginnslag = listOf(
+                Endringslogginnslag(
+                    saksbehandlerident = null,
+                    kilde = KildeSystem.KABAL,
+                    handling = Handling.ENDRING,
+                    felt = Felt.AVSLUTTET_AV_SAKSBEHANDLER,
+                    behandlingId = UUID.randomUUID(),
+                    tidspunkt = LocalDateTime.now(),
+                    fraVerdi = null,
+                    tilVerdi = null,
+                )
+            )
+        )
+
+        val ankeITrygderettenbehandlingEndretEvent = BehandlingEndretEvent(
+            behandling = ankeITrygderettenbehandlingOMP,
+            endringslogginnslag = listOf(
+                Endringslogginnslag(
+                    saksbehandlerident = null,
+                    kilde = KildeSystem.KABAL,
+                    handling = Handling.ENDRING,
+                    felt = Felt.AVSLUTTET,
+                    behandlingId = UUID.randomUUID(),
+                    tidspunkt = LocalDateTime.now(),
+                    fraVerdi = null,
+                    tilVerdi = null,
+                )
+            )
+        )
+
+        assertTrue(statistikkTilDVHService.shouldSendStats(klagebehandlingEndretEvent))
+        assertFalse(statistikkTilDVHService.shouldSendStats(klagebehandlingHJEEndretEvent))
+        assertTrue(statistikkTilDVHService.shouldSendStats(ankebehandlingEndretEvent))
+        assertFalse(statistikkTilDVHService.shouldSendStats(ankeITrygderettenbehandlingEndretEvent))
+    }
+
+    private val klagebehandlingOMP = Klagebehandling(
+        mottattVedtaksinstans = LocalDate.now(),
+        avsenderSaksbehandleridentFoersteinstans = null,
+        avsenderEnhetFoersteinstans = "",
+        kommentarFraFoersteinstans = null,
+        mottakId = UUID.randomUUID(),
+        innsendt = null,
+        klager = Klager(
+            partId = PartId(
+                type = PartIdType.PERSON,
+                value = ""
+            ), prosessfullmektig = null
+        ),
+        sakenGjelder = SakenGjelder(
+            partId = PartId(
+                type = PartIdType.PERSON,
+                value = ""
+            ), skalMottaKopi = false
+        ),
+        ytelse = Ytelse.OMS_OMP,
+        type = Type.KLAGE,
+        kildeReferanse = "",
+        dvhReferanse = null,
+        fagsystem = Fagsystem.K9,
+        fagsakId = "",
+        mottattKlageinstans = LocalDateTime.now(),
+        frist = LocalDate.now(),
+        tildeling = null,
+        tildelingHistorikk = mutableSetOf(),
+        kakaKvalitetsvurderingId = null,
+        kakaKvalitetsvurderingVersion = 0,
+        created = LocalDateTime.now(),
+        modified = LocalDateTime.now(),
+        delbehandlinger = setOf(),
+        saksdokumenter = mutableSetOf(),
+        hjemler = setOf(),
+        sattPaaVent = null
+    )
+
+    private val klagebehandlingHJE = Klagebehandling(
+        mottattVedtaksinstans = LocalDate.now(),
+        avsenderSaksbehandleridentFoersteinstans = null,
+        avsenderEnhetFoersteinstans = "",
+        kommentarFraFoersteinstans = null,
+        mottakId = UUID.randomUUID(),
+        innsendt = null,
+        klager = Klager(
+            partId = PartId(
+                type = PartIdType.PERSON,
+                value = ""
+            ), prosessfullmektig = null
+        ),
+        sakenGjelder = SakenGjelder(
+            partId = PartId(
+                type = PartIdType.PERSON,
+                value = ""
+            ), skalMottaKopi = false
+        ),
+        ytelse = Ytelse.HJE_HJE,
+        type = Type.KLAGE,
+        kildeReferanse = "",
+        dvhReferanse = null,
+        fagsystem = Fagsystem.IT01,
+        fagsakId = "",
+        mottattKlageinstans = LocalDateTime.now(),
+        frist = LocalDate.now(),
+        tildeling = null,
+        tildelingHistorikk = mutableSetOf(),
+        kakaKvalitetsvurderingId = null,
+        kakaKvalitetsvurderingVersion = 0,
+        created = LocalDateTime.now(),
+        modified = LocalDateTime.now(),
+        delbehandlinger = setOf(),
+        saksdokumenter = mutableSetOf(),
+        hjemler = setOf(),
+        sattPaaVent = null
+    )
+
+    private val ankebehandlingOMP = Ankebehandling(
+        mottakId = UUID.randomUUID(),
+        innsendt = null,
+        klager = Klager(
+            partId = PartId(
+                type = PartIdType.PERSON,
+                value = ""
+            ), prosessfullmektig = null
+        ),
+        sakenGjelder = SakenGjelder(
+            partId = PartId(
+                type = PartIdType.PERSON,
+                value = ""
+            ), skalMottaKopi = false
+        ),
+        ytelse = Ytelse.OMS_OMP,
+        type = Type.ANKE,
+        kildeReferanse = "",
+        dvhReferanse = null,
+        fagsystem = Fagsystem.K9,
+        fagsakId = "",
+        mottattKlageinstans = LocalDateTime.now(),
+        frist = LocalDate.now(),
+        tildeling = null,
+        tildelingHistorikk = mutableSetOf(),
+        kakaKvalitetsvurderingId = null,
+        kakaKvalitetsvurderingVersion = 0,
+        created = LocalDateTime.now(),
+        modified = LocalDateTime.now(),
+        delbehandlinger = setOf(),
+        saksdokumenter = mutableSetOf(),
+        hjemler = setOf(),
+        sattPaaVent = null,
+        klageVedtaksDato = null,
+        klageBehandlendeEnhet = "",
+        klagebehandlingId = null,
+    )
+
+    private val ankeITrygderettenbehandlingOMP = AnkeITrygderettenbehandling(
+        klager = Klager(
+            partId = PartId(
+                type = PartIdType.PERSON,
+                value = ""
+            ), prosessfullmektig = null
+        ),
+        sakenGjelder = SakenGjelder(
+            partId = PartId(
+                type = PartIdType.PERSON,
+                value = ""
+            ), skalMottaKopi = false
+        ),
+        ytelse = Ytelse.OMS_OMP,
+        type = Type.ANKE_I_TRYGDERETTEN,
+        kildeReferanse = "",
+        dvhReferanse = null,
+        fagsystem = Fagsystem.K9,
+        fagsakId = "",
+        mottattKlageinstans = LocalDateTime.now(),
+        frist = LocalDate.now(),
+        tildeling = null,
+        tildelingHistorikk = mutableSetOf(),
+        kakaKvalitetsvurderingId = null,
+        kakaKvalitetsvurderingVersion = 0,
+        created = LocalDateTime.now(),
+        modified = LocalDateTime.now(),
+        delbehandlinger = setOf(),
+        saksdokumenter = mutableSetOf(),
+        hjemler = setOf(),
+        sattPaaVent = null,
+        sendtTilTrygderetten = LocalDateTime.now(),
+        kjennelseMottatt = null,
+    )
+}


### PR DESCRIPTION
Added tests for shouldSendStats.
Delete wrongly produced kafka events.