### PR TITLE
Only check saksbehandler access if needed.

### DIFF
--- a/src/main/kotlin/no/nav/klage/dokument/service/DokumentUnderArbeidService.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/service/DokumentUnderArbeidService.kt
@@ -737,7 +737,7 @@ class DokumentUnderArbeidService(
         //Validate part
         partSearchService.searchPart(
             identifikator = avsenderInput.identifikator,
-            skipAccessControl = true
+            systemUserContext = true
         )
 
         val dokumentUnderArbeid = getDokumentUnderArbeid(dokumentId)
@@ -903,7 +903,7 @@ class DokumentUnderArbeidService(
             if (mottaker.identifikator != null) {
                 val part = partSearchService.searchPart(
                     identifikator = mottaker.identifikator,
-                    skipAccessControl = systemContext
+                    systemUserContext = systemContext
                 )
 
                 when (part.type) {
@@ -1370,7 +1370,7 @@ class DokumentUnderArbeidService(
             if (mottaker.identifikator != null) {
                 val part = partSearchService.searchPartWithUtsendingskanal(
                     identifikator = mottaker.identifikator,
-                    skipAccessControl = true,
+                    systemUserContext = true,
                     sakenGjelderId = behandling.sakenGjelder.partId.value,
                     tema = behandling.ytelse.toTema(),
                     systemContext = systemContext,
@@ -2137,13 +2137,13 @@ class DokumentUnderArbeidService(
             sakenGjelderIdentifikator = behandling.sakenGjelder.partId.value,
             sakenGjelderName = partSearchService.searchPart(
                 identifikator = behandling.sakenGjelder.partId.value,
-                skipAccessControl = systemContext
+                systemUserContext = systemContext
             ).name,
             ytelse = behandling.ytelse,
             klagerIdentifikator = behandling.klager.partId.value,
             klagerName = partSearchService.searchPart(
                 identifikator = behandling.klager.partId.value,
-                skipAccessControl = systemContext
+                systemUserContext = systemContext
             ).name,
             avsenderEnhetId = avsenderEnhetId,
         )
@@ -2204,7 +2204,7 @@ class DokumentUnderArbeidService(
     ): DokumentUnderArbeidAsHoveddokument {
         val sakenGjelderName = partSearchService.searchPart(
             identifikator = behandling.sakenGjelder.partId.value,
-            skipAccessControl = true
+            systemUserContext = true
         ).name
 
         val bytes = kabalJsonToPdfService.getForlengetBehandlingstidPDF(
@@ -2215,7 +2215,7 @@ class DokumentUnderArbeidService(
             klagerName = if (behandling.klager.partId.value != behandling.sakenGjelder.partId.value) {
                 partSearchService.searchPart(
                     identifikator = behandling.klager.partId.value,
-                    skipAccessControl = true
+                    systemUserContext = true
                 ).name
             } else {
                 sakenGjelderName

--- a/src/main/kotlin/no/nav/klage/dokument/service/PreviewService.kt
+++ b/src/main/kotlin/no/nav/klage/dokument/service/PreviewService.kt
@@ -35,7 +35,7 @@ class PreviewService(
 
         val sakenGjelderName = partSearchService.searchPart(
             identifikator = input.sakenGjelder,
-            skipAccessControl = true
+            systemUserContext = true
         ).name
 
         return kabalJsonToPdfService.getSvarbrevPDF(
@@ -48,7 +48,7 @@ class PreviewService(
             klagerName = if (input.klager != null) {
                 partSearchService.searchPart(
                     identifikator = input.klager,
-                    skipAccessControl = true
+                    systemUserContext = true
                 ).name
             } else {
                 sakenGjelderName

--- a/src/main/kotlin/no/nav/klage/oppgave/api/controller/SearchController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/controller/SearchController.kt
@@ -54,7 +54,7 @@ class SearchController(
 
         return partSearchService.searchPartWithUtsendingskanal(
             identifikator = input.identifikator,
-            skipAccessControl = false,
+            systemUserContext = false,
             sakenGjelderId = input.sakenGjelderId,
             tema = Ytelse.of(input.ytelseId).toTema(),
             systemContext = false

--- a/src/main/kotlin/no/nav/klage/oppgave/service/AutomaticSvarbrevService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/AutomaticSvarbrevService.kt
@@ -265,7 +265,7 @@ class AutomaticSvarbrevService(
         if (receiver.identifikator != null) {
             val part = partSearchService.searchPart(
                 identifikator = receiver.identifikator,
-                skipAccessControl = true
+                systemUserContext = true
             )
 
             when (part.type) {
@@ -302,13 +302,13 @@ class AutomaticSvarbrevService(
             sakenGjelderIdentifikator = behandling.sakenGjelder.partId.value,
             sakenGjelderName = partSearchService.searchPart(
                 identifikator = behandling.sakenGjelder.partId.value,
-                skipAccessControl = true
+                systemUserContext = true
             ).name,
             ytelse = behandling.ytelse,
             klagerIdentifikator = behandling.klager.partId.value,
             klagerName = partSearchService.searchPart(
                 identifikator = behandling.klager.partId.value,
-                skipAccessControl = true,
+                systemUserContext = true,
             ).name,
             //Hardcode KA Oslo
             avsenderEnhetId = Enhet.E4291.navn,

--- a/src/main/kotlin/no/nav/klage/oppgave/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/BehandlingService.kt
@@ -1429,7 +1429,7 @@ class BehandlingService(
         } else if (behandling.prosessfullmektig!!.partId != null) {
             val searchPartViewWithUtsendingskanal = partSearchService.searchPartWithUtsendingskanal(
                 identifikator = behandling.prosessfullmektig?.partId?.value!!,
-                skipAccessControl = true,
+                systemUserContext = true,
                 sakenGjelderId = behandling.sakenGjelder.partId.value,
                 tema = behandling.ytelse.toTema(),
                 systemContext = false,
@@ -1525,7 +1525,7 @@ class BehandlingService(
         val partView =
             partSearchService.searchPartWithUtsendingskanal(
                 identifikator = behandling.klager.partId.value,
-                skipAccessControl = true,
+                systemUserContext = true,
                 sakenGjelderId = behandling.sakenGjelder.partId.value,
                 tema = behandling.ytelse.toTema(),
                 systemContext = false,

--- a/src/main/kotlin/no/nav/klage/oppgave/service/ForlengetBehandlingstidDraftService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/ForlengetBehandlingstidDraftService.kt
@@ -228,7 +228,7 @@ class ForlengetBehandlingstidDraftService(
             val name = behandling.prosessfullmektig!!.partId?.value?.let {
                 partSearchService.searchPart(
                     identifikator = it,
-                    skipAccessControl = true
+                    systemUserContext = true
                 ).name
             } ?: behandling.prosessfullmektig?.navn
             name
@@ -291,7 +291,7 @@ class ForlengetBehandlingstidDraftService(
 
         val sakenGjelderName = partSearchService.searchPart(
             identifikator = behandling.sakenGjelder.partId.value,
-            skipAccessControl = true
+            systemUserContext = true
         ).name
 
         val forlengetBehandlingstidDraft = behandling.forlengetBehandlingstidDraft
@@ -304,7 +304,7 @@ class ForlengetBehandlingstidDraftService(
             klagerName = if (behandling.klager.partId.value != behandling.sakenGjelder.partId.value) {
                 partSearchService.searchPart(
                     identifikator = behandling.klager.partId.value,
-                    skipAccessControl = true
+                    systemUserContext = true
                 ).name
             } else {
                 sakenGjelderName


### PR DESCRIPTION
`skipAccessControl` renamed to `systemUserContext`.