### PR TITLE
Korriger url for kall til logiskVedlegg på dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/clients/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/dokarkiv/DokarkivClient.kt
@@ -47,7 +47,7 @@ class DokarkivClient(
     ): AddLogiskVedleggResponse {
         try {
             val response = dokarkivWebClient.post()
-                .uri("/dokumentInfo/${dokumentInfoId}/logiskVedlegg/")
+                .uri("/dokumentInfo/${dokumentInfoId}/logiskVedlegg")
                 .header(
                     HttpHeaders.AUTHORIZATION,
                     "Bearer ${tokenUtil.getSaksbehandlerAccessTokenWithDokarkivScope()}"


### PR DESCRIPTION
Dokarkiv vil snart ikke godta URL-er med trailing slash, derfor må dette endres